### PR TITLE
Add note on keys and docker-compose.

### DIFF
--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -268,6 +268,8 @@ If you want to change the key, remove the `id_ed25519` and `id_ed25519.pub` file
 
 {{% notice note %}}
 If you are using docker-compose and keys don't exist, the start of containers will create differents keys in hbbs and hbbr folders.
+
 You could create keys manually in hbbs and copy them to hbbr, before starting the containers.
+
 Or you could stop hbbr container and copy the keys from hbbs to hbbr folder, and restart the container.
 {{% /notice %}}

--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -265,3 +265,9 @@ If you want to prohibit users without the key from establishing non-encrypted co
 ```
 
 If you want to change the key, remove the `id_ed25519` and `id_ed25519.pub` files and restart `hbbs`/`hbbr`，`hbbs` will generate a new key pair.
+
+{{% notice note %}}
+If you are using docker-compose and keys don't exist, the start of containers will create differents keys in hbbs and hbbr folders.
+You could create keys manually in hbbs and copy them to hbbr, before starting the containers.
+Or you could stop hbbr container and copy the keys from hbbs to hbbr folder, and restart the container.
+{{% /notice %}}


### PR DESCRIPTION
If you are running docker-compose.yml as specifiy, the keys are generated on the 2 containers ... but they are differents.
I had the issue and errors are not explicite.

I add a comment in the documentation to help users to manage the case.
