### PR TITLE
Removed git checkout 2021.12.01 from docs

### DIFF
--- a/content/dev/build/windows/_index.en.md
+++ b/content/dev/build/windows/_index.en.md
@@ -18,9 +18,6 @@ Use [git-bash](https://git-scm.com/download/win) to run the following commandsï¼
 
 ```shell
   git clone https://github.com/microsoft/vcpkg
-  cd vcpkg
-  git checkout 2021.12.01
-  cd ..
   vcpkg/bootstrap-vcpkg.bat
   export VCPKG_ROOT=$PWD/vcpkg
   vcpkg/vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static


### PR DESCRIPTION
Removed 'git checkout 2021.12.01' step from VCPKG instructions, as it will not compile with this branch/changeset. Just use master instead and it will work fine.