### PR TITLE
Updated Rust build script

### DIFF
--- a/content/dev/build/android/_index.en.md
+++ b/content/dev/build/android/_index.en.md
@@ -22,6 +22,7 @@ unzip android-ndk-r22b-linux-x86_64.zip
 dart pub global activate ffigen 5.0.1
 # on Ubuntu 18, it is: sudo apt install libclang-9-dev
 sudo apt-get install libclang-dev
+sudo apt install gcc-multilib
 
 git clone https://github.com/rustdesk/rustdesk
 cd rustdesk


### PR DESCRIPTION
When I tried to build Rust on my machine (I Executed "VCPKG_ROOT=$HOME/vcpkg ANDROID_NDK_HOME=$HOME/android-ndk-r22b flutter/ndk_arm64.sh" part) I found that it's missing 2 header files 'bits/wordsize.h' and 'bits/libc-header-start.h'. This should fix this issue