### PR TITLE
Change "cargo run" with "python3 build.py"

### DIFF
--- a/content/dev/build/windows/_index.en.md
+++ b/content/dev/build/windows/_index.en.md
@@ -57,5 +57,5 @@ cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll
 mv sciter.dll target/debug
-cargo run
+python3 ./build.py
 ```


### PR DESCRIPTION
As of today, if you follow the docs you'll not be able to "cargo run" and build the app: you'll build will fail making you wonder what have you done wrong. Building with build.py after following the docs, instead, will just work and compile the app. The default, then, should be python3 build.py (atleast until this problem it's fixed and you can "cargo run" succesfully on Windows).