### PR TITLE
Revert "Change "cargo run" with "python3 build.py""

### DIFF
--- a/content/dev/build/windows/_index.en.md
+++ b/content/dev/build/windows/_index.en.md
@@ -57,5 +57,5 @@ cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll
 mv sciter.dll target/debug
-python3 ./build.py
+cargo run
 ```


### PR DESCRIPTION
Reverts rustdesk/doc.rustdesk.com#134