### PR TITLE
Update documentation about the delimiter character

### DIFF
--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -232,7 +232,7 @@ Change `rustdesk.exe` to rustdesk-`host=<host-ip-or-name>,key=<public-key-string
 {{% notice note %}}
 You need to set both `host` and `key`, missing either one will not work.
 
-Optionally add an `#` character after the key, before the `.exe` part as a delimiter, to avoid the key being mangled if Windows or the browser renames the file when downloading duplicated names.
+Optionally add a `,` (comma) character after the key, before the `.exe` part as a delimiter, to avoid the key being mangled if Windows or the browser renames the file when downloading duplicated names.
 
 If there are invalid characters in the key which can not be used in a Windows file name, please remove the
 `id_ed25519` file from your server and restart `hbbs`/`hbbr`. This will cause the `id_ed25519.pub` file to regenerate. You may need to


### PR DESCRIPTION
It was changed to a comma in rustdesk/rustdesk@5a25573125f6a5b9064ab079b7cb1cb4a1eecbba