### PR TITLE
add description for experimental Wayland support

### DIFF
--- a/content/manual/linux/_index.de.md
+++ b/content/manual/linux/_index.de.md
@@ -30,9 +30,10 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 erforderlich
+### ~~X11 erforderlich~~
+~~RustDesk unterstützt Wayland noch nicht; Sie müssen manuell zu X11 wechseln.~~
 
-RustDesk unterstützt Wayland noch nicht; Sie müssen manuell zu X11 wechseln.
+RustDesk unterstützt jetzt experimentell Wayland. Um dieses Feature zu aktivieren, musst du möglicherweise die Nightly-Version herunterladen.
 
 #### Server anzeigen
 

--- a/content/manual/linux/_index.en.md
+++ b/content/manual/linux/_index.en.md
@@ -30,9 +30,10 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 Required
+### ~~X11 Required~~
+~~RustDesk does not support wayland yet; you need switch to X11 manually.~~
 
-RustDesk does not support wayland yet; you need switch to X11 manually.
+RustDesk now has experimental Wayland support. You may need to download the nightly version to enable this feature.
 
 #### Display Server
 

--- a/content/manual/linux/_index.es.md
+++ b/content/manual/linux/_index.es.md
@@ -27,9 +27,10 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 Required
+### ~~X11 Required~~
+~~RustDesk aún no admite wayland, debe cambiar a X11. RustDesk lo guiará para cambiar a X11.~~
 
-RustDesk aún no admite wayland, debe cambiar a X11. RustDesk lo guiará para cambiar a X11.
+RustDesk ahora cuenta con soporte experimental para Wayland. Es posible que debas descargar la versión nocturna para habilitar esta función.
 
 | Haga clic en "Fix it" | corrección para la pantalla de inicio de sesión | Ingrese su contraseña |
 | ---- | ---- | --- |

--- a/content/manual/linux/_index.fr.md
+++ b/content/manual/linux/_index.fr.md
@@ -30,9 +30,10 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 nécessaire
+### ~~X11 nécessaire~~
+~~RustDesk ne prend pas encore en charge wayland ; vous devez passer manuellement à X11.~~
 
-RustDesk ne prend pas encore en charge wayland ; vous devez passer manuellement à X11.
+RustDesk dispose désormais d'une prise en charge expérimentale de Wayland. Vous devrez peut-être télécharger la version nightly pour activer cette fonctionnalité.
 
 #### Serveur d'affichage
 

--- a/content/manual/linux/_index.nl.md
+++ b/content/manual/linux/_index.nl.md
@@ -30,9 +30,9 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 Vereist
-
-RustDesk ondersteunt wayland nog niet; u moet handmatig overschakelen naar X11.
+### ~~X11 Vereist~~
+~~RustDesk ondersteunt wayland nog niet; u moet handmatig overschakelen naar X11.~~
+RustDesk heeft nu experimentele Wayland-ondersteuning. Je moet mogelijk de nightly-versie downloaden om deze functie in te schakelen.
 
 #### Toon Server
 

--- a/content/manual/linux/_index.ru.md
+++ b/content/manual/linux/_index.ru.md
@@ -27,8 +27,10 @@ sudo pacman -U ./rustdesk-<version>.pkg.tar.zst
 sudo zypper install --allow-unsigned-rpm ./rustdesk-<version>-suse.rpm
 ```
 
-### X11 обязателен 
-RustDesk пока не поддерживает Wayland. Необходимо перейти на X11 вручную.
+### ~~X11 обязателен~~
+~~RustDesk пока не поддерживает Wayland. Необходимо перейти на X11 вручную.~~
+
+В RustDesk теперь есть экспериментальная поддержка Wayland. Возможно, вам потребуется скачать ночную версию, чтобы включить эту функцию.
 
 #### Сервер отображения
 Ubuntu: https://askubuntu.com/questions/1260142/ubuntu-set-default-login-desktop


### PR DESCRIPTION
Now, RustDesk has experimental Wayland support, and I have added it to the documentation.