### PR TITLE
update english installation instructions

### DIFF
--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -33,6 +33,9 @@ wget https://raw.githubusercontent.com/techahold/rustdeskinstall/master/install.
 chmod +x install.sh
 ./install.sh
 ```
+
+> Note: if you aren't running as root, you need to run `sudo ./install.sh` instead.
+
 There is also an update script on [Techahold's](https://github.com/techahold/rustdeskinstall) repository.
 
 ## Install your own server as systemd service using deb file for debian distros


### PR DESCRIPTION
Based on the switch in nature of the install script, the instructions should be updated to indicate someone needs to use root.

NOTE: this patch should not be accepted until https://github.com/techahold/rustdeskinstall/pull/43 is merged.

Also, updates should be made to the internationalized versions of this page.