### PR TITLE
Fixing Docker info

### DIFF
--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -68,39 +68,27 @@ For running the docker files with the `docker-compose.yml` as described here you
 ```yaml
 version: '3'
 
-networks:
-  rustdesk-net:
-    external: false
-
 services:
   hbbs:
     container_name: hbbs
-    ports:
-      - 21115:21115
-      - 21116:21116
-      - 21116:21116/udp
-      - 21118:21118
     image: rustdesk/rustdesk-server:latest
-    command: hbbs -r example.com:21117
+    command: hbbs
     volumes:
       - ./data:/root
-    networks:
-      - rustdesk-net
+    network_mode: "host"
+
     depends_on:
       - hbbr
     restart: unless-stopped
 
+
   hbbr:
     container_name: hbbr
-    ports:
-      - 21117:21117
-      - 21119:21119
     image: rustdesk/rustdesk-server:latest
     command: hbbr
     volumes:
       - ./data:/root
-    networks:
-      - rustdesk-net
+    network_mode: "host"
     restart: unless-stopped
 ```
 

--- a/content/self-host/install/_index.en.md
+++ b/content/self-host/install/_index.en.md
@@ -47,8 +47,8 @@ You need to have Docker/Podman installed to run a rustdesk-server as a docker co
 ### Docker examples
 ```bash
 sudo docker image pull rustdesk/rustdesk-server
-sudo docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v `pwd`:/root -td --net=host rustdesk/rustdesk-server hbbs -r <relay-server-ip[:port]>
-sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v `pwd`:/root -td --net=host rustdesk/rustdesk-server hbbr
+sudo docker run --name hbbs -v `pwd`:/root -td --net=host rustdesk/rustdesk-server hbbs -r <relay-server-ip[:port]>
+sudo docker run --name hbbr -v `pwd`:/root -td --net=host rustdesk/rustdesk-server hbbr
 ```
 <a name="net-host"></a>
 

--- a/content/self-host/pro/_index.en.md
+++ b/content/self-host/pro/_index.en.md
@@ -42,3 +42,59 @@ Almost as the same as [the open source version](/docs/en/self-host/install/), bu
 ### One more port (or use a proxy)
 
 One more TCP port `21114` is added for web console, please also add this port when you set firewall rules and docker port mapping.
+
+### Docker
+
+Install Docker with (this)[https://docs.docker.com/engine/install/] guide.
+
+Run the following commands:
+```bash
+sudo docker image pull rustdesk/rustdesk-server-pro
+sudo docker run --name hbbs -p 21114:21114 -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbs
+sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbr
+```
+{{% notice note %}}
+The above example uses `sudo` and `--net=host`, this will not work on windows please remove these commands, if you remove `--net=host` please check below.
+{{% /notice %}}
+
+```bash
+macaddrhbbs=$(echo -n A0-62-2F; dd bs=1 count=3 if=/dev/random 2>/dev/null |hexdump -v -e '/1 "-%02X"')
+sudo docker image pull rustdesk/rustdesk-server-pro
+sudo docker run --name hbbs -p 21114:21114 -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v `pwd`:/root -td --mac-address="$macaddrhbbs" --restart unless-stopped rustdesk/rustdesk-server-pro hbbs
+sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v `pwd`:/root -td --restart unless-stopped rustdesk/rustdesk-server-pro hbbr
+```
+
+### Docker Compose
+
+With Docker Compose you HAVE to use `network_mode: "host"`. Install using (this)[https://docs.docker.com/engine/install/] guide.
+
+Copy the below into docker-compose.yml
+
+```yaml
+version: '3'
+
+services:
+  hbbs:
+    container_name: hbbs
+    image: rustdesk/rustdesk-server-pro:latest
+    command: hbbs
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+
+    depends_on:
+      - hbbr
+    restart: unless-stopped
+
+
+  hbbr:
+    container_name: hbbr
+    image: rustdesk/rustdesk-server-pro:latest
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+The run `docker compose up -d`

--- a/content/self-host/pro/_index.en.md
+++ b/content/self-host/pro/_index.en.md
@@ -50,8 +50,8 @@ Install Docker with (this)[https://docs.docker.com/engine/install/] guide.
 Run the following commands:
 ```bash
 sudo docker image pull rustdesk/rustdesk-server-pro
-sudo docker run --name hbbs -p 21114:21114 -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbs
-sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbr
+sudo docker run --name hbbs -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbs
+sudo docker run --name hbbr -v `pwd`:/root -td --net=host --restart unless-stopped rustdesk/rustdesk-server-pro hbbr
 ```
 {{% notice note %}}
 The above example uses `sudo` and `--net=host`, this will not work on windows please remove these commands, if you remove `--net=host` please check below.


### PR DESCRIPTION
added to install with option to not use net=host and docker compose files in opensource and pro