### PR TITLE
Update docker guide to make example more secure

### DIFF
--- a/content/self-host/rustdesk-server-oss/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.en.md
@@ -15,10 +15,12 @@ By default, `hbbs` listens on 21115 (TCP), 21116 (TCP/UDP) and 21118 (TCP), `hbb
 
 #### Docker examples
 
+Note: You may need to add your user to the docker group to make this work
+
 ```sh
-sudo docker image pull rustdesk/rustdesk-server
-sudo docker run --name hbbs -v ./data:/root -td --net=host rustdesk/rustdesk-server hbbs -r <relay-server-ip[:port]>
-sudo docker run --name hbbr -v ./data:/root -td --net=host rustdesk/rustdesk-server hbbr
+docker image pull rustdesk/rustdesk-server
+docker run --name hbbs -v ./data:/root -td -p "21115:21115" -p "21116:21116" -p "21116:21116/udp" -p "21118:21118" rustdesk/rustdesk-server hbbs -r <relay-server-ip[:port]>
+docker run --name hbbr -v ./data:/root -td -p "21117:21117" -p "21119:21119" rustdesk/rustdesk-server hbbr
 ```
 <a name="net-host"></a>
 
@@ -45,8 +47,11 @@ services:
     command: hbbs
     volumes:
       - ./data:/root
-    network_mode: "host"
-
+    ports:
+      - "21115:21115"
+      - "21116:21116"
+      - "21116:21116/udp"
+      - "21118:21118"
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -58,6 +63,9 @@ services:
     command: hbbr
     volumes:
       - ./data:/root
-    network_mode: "host"
+    ports:
+      - "21117:21117"
+      - "21119:21119"
     restart: unless-stopped
+
 ```


### PR DESCRIPTION
I Updated this documentation page to harden the security of anyone who follows this guide. There were two main issues with the old page. 

#### Issue 1
 - The guide used sudo to run docker when it wasn't needed. This is a potential security issue and is bad practice at best. The right answer is to add your user to the docker group so you can use it without root.

#### Issue 2 (worst)
 - The guide recommended people set the networking mode to host. **This is a major security issue**. By setting network to host you are allowing any software in the container root access to your machine because software inside the networking host container can get out of the container. This isn't terrible by itself unless something happens to the Rustdesk server like a supply chain attack or a zero day. Docker provides excellent isolation and it doesn't make sense to not use it. 