### PR TITLE
Update _index.zh-cn.md

### DIFF
--- a/content/self-host/rustdesk-server-oss/install/_index.zh-cn.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.zh-cn.md
@@ -37,8 +37,7 @@ Linux版本在Centos7构建，在 Centos7/8，Ubuntu 18/20上测试过，Debian�
 或者使用 pm2 运行 hbbs/hbbr
 
 ```
-pm2 start hbbs -- -r <relay-server-ip[:port]> 
-pm2 start hbbr 
+pm2 start hbbr hbbs -- -r <relay-server-ip[:port]> 
 ```
 
 <a name="demo"></a>


### PR DESCRIPTION
更改 pm2 启动 hbbs 和 hbbr 命令
我发现当使用 pm2 start hbbr 或 pm2 start hbbs 分别启动时,当启动其中一个其他的将会停止。
I discovered that when starting either pm2 start hbbr or pm2 start hbbs separately, the other process will stop.
![putty_DHEvl2mBJi](https://github.com/rustdesk/doc.rustdesk.com/assets/85749931/bfe31829-bb88-48b3-94d8-8c3f20fba6fa)
当使用 pm2 start hbbr hbbs 时，可以同时启用。
When using pm2 start hbbr hbbs, you can enable both.
![putty_8heNkTIonh](https://github.com/rustdesk/doc.rustdesk.com/assets/85749931/c2b007ed-0678-44f6-ad59-e77b282b26f5)
我不清楚是我的操作问题还是 PM2 的问题，但是使用这个命令确实可以解决问题。
希望可以修改一下文档。
It is unclear whether the issue is specific to me or PM2. However, using this command may resolve the problem.
It is recommended that the documentation be updated accordingly.
