### PR TITLE
Added version tag to image, manifest error if no tag (no latest tag available)

### DIFF
--- a/content/dev/build/web/_index.en.md
+++ b/content/dev/build/web/_index.en.md
@@ -164,13 +164,13 @@ If you do not want to build the Docker image yourself, you can use the image I b
 - Pull the image:
 
 ```sh
-docker pull keyurbhole/flutter_web_desk
+docker pull keyurbhole/flutter_web_desk:v1.0.0
 ```
 
 - Run the image:
 
 ```sh
-docker run -p 5000:5000 keyurbhole/flutter_web_desk
+docker run -p 5000:5000 keyurbhole/flutter_web_desk:v1.0.0
 ```
 
 - Open your browser and go to `localhost:5000` to see the web app.


### PR DESCRIPTION
Added version tag to image. Without the version tag it cannot find the image to download when performing pull.