### PR TITLE
Update _index.en.md

### DIFF
--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -67,12 +67,10 @@ function getLatest()
     }
 
     # Create object to return
-    $Result = New-Object PSObject -Property
-    @{
-        Version = $Version
-        Downloadlink = $Downloadlink
-    }
-
+    $params += @{Version = $Version}
+    $params += @{Downloadlink = $Downloadlink}
+    $Result = New-Object PSObject -Property $params
+    
     return($Result)
 }
 


### PR DESCRIPTION
When using deployment tools (like PDQ) the multi-line params caused an exception when running the nested ps1 script. Changing it to an by-line approach solved this.