### PR TITLE
optimization for action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
@@ -28,8 +28,8 @@ jobs:
 
       - name: Build
         run: |
-          sudo apt update -y
-          sudo apt install -y git
+          #sudo apt update
+          #sudo apt install -y git
           git clone https://github.com/matcornic/hugo-theme-learn themes/hugo-theme-learn --depth=1
           hugo --minify
           cd public; tar czf x *


### PR DESCRIPTION
Upgrade `actions/checkout@v3` to `actions/checkout@v4`

There is nothing call `apt update -y`, because it just update package list.

Comment out but not delete `apt update` and `apt install git -y` because `git` is already installed (If not, it is joke because it is the runner served by GitHub), and `actions/checkout` will git clone the repo in first place, also keep it if you wanna install `go` on the future, some hugo theme or module need `go` installed