### PR TITLE
Update Compose Docs

### DIFF
--- a/content/self-host/rustdesk-server-oss/Docker/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.de.md
@@ -34,7 +34,7 @@ Sie können die Protokolle mit `docker logs hbbs` ansehen, wenn sie mit `-td` ni
 {{% /notice %}}
 
 #### Docker Compose-Beispiele
-Um die Dockerdateien mit `docker-compose.yml` wie hier beschrieben ausführen zu können, müssen Sie [Docker Compose](https://docs.docker.com/compose/) installiert haben.
+Um die Dockerdateien mit `compose.yml` wie hier beschrieben ausführen zu können, müssen Sie [Docker Compose](https://docs.docker.com/compose/) installiert haben.
 ```yaml
 services:
   hbbs:

--- a/content/self-host/rustdesk-server-oss/Docker/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.de.md
@@ -36,8 +36,6 @@ Sie können die Protokolle mit `docker logs hbbs` ansehen, wenn sie mit `-td` ni
 #### Docker Compose-Beispiele
 Um die Dockerdateien mit `docker-compose.yml` wie hier beschrieben ausführen zu können, müssen Sie [Docker Compose](https://docs.docker.com/compose/) installiert haben.
 ```yaml
-version: '3'
-
 services:
   hbbs:
     container_name: hbbs

--- a/content/self-host/rustdesk-server-oss/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.en.md
@@ -36,7 +36,6 @@ If you can not see logs with `-td`, you can see logs via `docker logs hbbs`. Or 
 #### Docker Compose examples
 For running the Docker files with the `docker-compose.yml` as described here you need to have [Docker Compose](https://docs.docker.com/compose/) installed.
 ```yaml
-version: '3'
 
 services:
   hbbs:

--- a/content/self-host/rustdesk-server-oss/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.en.md
@@ -34,7 +34,7 @@ If you can not see logs with `-td`, you can see logs via `docker logs hbbs`. Or 
 {{% /notice %}}
 
 #### Docker Compose examples
-For running the Docker files with the `docker-compose.yml` as described here you need to have [Docker Compose](https://docs.docker.com/compose/) installed.
+For running the Docker files with the `compose.yml` as described here you need to have [Docker Compose](https://docs.docker.com/compose/) installed.
 ```yaml
 
 services:

--- a/content/self-host/rustdesk-server-oss/install/_index.fr.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.fr.md
@@ -58,7 +58,7 @@ Si `--net=host` fonctionne , l'option `-p` ne sera pas utile. Pour windows, omet
 {{% /notice %}}
 
 ### Exemples avec Docker-Compose
-Pour exécuter les fichiers docker avec docker-compose.yml comme ci-dessous, vous devez avoir [**docker-compose**] (https://docs.docker.com/compose/) d'installé.
+Pour exécuter les fichiers docker avec compose.yml comme ci-dessous, vous devez avoir [**docker-compose**] (https://docs.docker.com/compose/) d'installé.
 
 ```yaml
 

--- a/content/self-host/rustdesk-server-oss/install/_index.fr.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.fr.md
@@ -61,7 +61,6 @@ Si `--net=host` fonctionne , l'option `-p` ne sera pas utile. Pour windows, omet
 Pour exécuter les fichiers docker avec docker-compose.yml comme ci-dessous, vous devez avoir [**docker-compose**] (https://docs.docker.com/compose/) d'installé.
 
 ```yaml
-version: '3'
 
 networks:
   rustdesk-net:

--- a/content/self-host/rustdesk-server-oss/install/_index.nl.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.nl.md
@@ -56,7 +56,7 @@ Als `--net=host` goed werkt, worden de `-p` opties niet gebruikt. Indien op Wind
 {{% /notice %}}
 
 ### Docker-Compose voorbeelden
-Voor het uitvoeren van de dockerbestanden met de docker-compose.yml zoals hier beschreven heb je [**docker-compose**](https://docs.docker.com/compose/) nodig en werkende.
+Voor het uitvoeren van de dockerbestanden met de compose.yml zoals hier beschreven heb je [**docker-compose**](https://docs.docker.com/compose/) nodig en werkende.
 ```yaml
 
 networks:

--- a/content/self-host/rustdesk-server-oss/install/_index.nl.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.nl.md
@@ -58,7 +58,6 @@ Als `--net=host` goed werkt, worden de `-p` opties niet gebruikt. Indien op Wind
 ### Docker-Compose voorbeelden
 Voor het uitvoeren van de dockerbestanden met de docker-compose.yml zoals hier beschreven heb je [**docker-compose**](https://docs.docker.com/compose/) nodig en werkende.
 ```yaml
-version: '3'
 
 networks:
   rustdesk-net:

--- a/content/self-host/rustdesk-server-oss/install/_index.zh-cn.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.zh-cn.md
@@ -71,7 +71,6 @@ sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v `pwd`:/root -td --n
 ##### Docker Compose
 
 ```yaml
-version: '3'
 
 networks:
   rustdesk-net:

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
@@ -37,7 +37,6 @@ Sie könnten die Zeile mit `hbbs` vorübergehend in die LAN-IP Ihres NAS ändern
 ![](images/dsm7_creating_project_init.png)
 
 ```yaml
-version: '3'
 services:
   hbbs:
     container_name: hbbs

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
@@ -28,7 +28,7 @@ Nach der Installation von "Container Manager" wird ein gemeinsamer Ordner `docke
 
 Öffnen Sie Ihren Container Manager, gehen Sie zu Project und klicken Sie auf Create.
 
-Geben Sie den Projektnamen `rustdesk-server` ein, ändern Sie Source von "Upload docker-compose.yml" zu "Create docker-compose.yml" und kopieren Sie den folgenden Inhalt in das Feld. Danach sollten Sie `rustdesk.example.com` (die auf Ihre `hbbr` verweist) durch die Domain ersetzen, die auf Ihr NAS verweist.
+Geben Sie den Projektnamen `rustdesk-server` ein, ändern Sie Source von "Upload compose.yml" zu "Create compose.yml" und kopieren Sie den folgenden Inhalt in das Feld. Danach sollten Sie `rustdesk.example.com` (die auf Ihre `hbbr` verweist) durch die Domain ersetzen, die auf Ihr NAS verweist.
 
 {{% notice note %}}
 Sie könnten die Zeile mit `hbbs` vorübergehend in die LAN-IP Ihres NAS ändern, wie auf dem Bild gelb markiert zu sehen. Nachdem Sie sich vergewissert haben, dass Ihr Server funktioniert, **sollten** Sie die Änderung zurücknehmen.

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
@@ -28,7 +28,7 @@ Open your File Station, create a folder named `rustdesk-server`(or whatever you 
 
 Open your Container Manager, go to Project and click Create.
 
-Enter the project name `rustdesk-server` and change Source from "Upload docker-compose.yml" to "Create docker-compose.yml", and copy following contents to the box. After you copied, you should replace `rustdesk.example.com` (Which point to your `hbbr`) to the domain that will point to your NAS.
+Enter the project name `rustdesk-server` and change Source from "Upload compose.yml" to "Create compose.yml", and copy following contents to the box. After you copied, you should replace `rustdesk.example.com` (Which point to your `hbbr`) to the domain that will point to your NAS.
 
 {{% notice note %}}
 You could modify the line with `hbbs` to your NAS's LAN IP temporarily just like the picture. After you verify your server is working, you **should** change back.

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
@@ -37,7 +37,6 @@ You could modify the line with `hbbs` to your NAS's LAN IP temporarily just like
 ![](images/dsm7_creating_project_init.png)
 
 ```yaml
-version: '3'
 services:
   hbbs:
     container_name: hbbs

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
@@ -35,7 +35,6 @@ Container Manager 為部分低階的 ARM64 的機型帶來支援，例如 j 系�
 ![](images/dsm7_creating_project_init.png)
 
 ````yaml
-version: '3'
 services:
   hbbs:
     container_name: hbbs

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
@@ -26,7 +26,7 @@ Container Manager 為部分低階的 ARM64 的機型帶來支援，例如 j 系�
 
 打開您的 Container Manager，前往專案並點擊新增。
 
-輸入您的專案名稱 `rustdesk-server` 然後變更來源從"上傳 docker-compose.yml" 至 "建立 docker-compose.yml"，接著複製下方內容到框框，在您複製貼上後，您應該將 `rustdesk.example.com` (它該指向到您的 `hbbr`) 改為會指向至您NAS的網域。
+輸入您的專案名稱 `rustdesk-server` 然後變更來源從"上傳 compose.yml" 至 "建立 compose.yml"，接著複製下方內容到框框，在您複製貼上後，您應該將 `rustdesk.example.com` (它該指向到您的 `hbbr`) 改為會指向至您NAS的網域。
 
 {{% notice note %}}
 如圖所示，您可以暫時將 `hbbs` 那行改為指向至您的NAS的 LAN IP，在您驗證您的伺服器可以正常運作後，您**應當**變更回來。

--- a/content/self-host/rustdesk-server-oss/ubuntu-server/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/ubuntu-server/_index.en.md
@@ -2,5 +2,5 @@
 title: Ubuntu Server
 weight: 30
 ---
-In Ubuntu Server, you have two method to deplay RustDesk Server, Docker or nornal `.deb` installation, Docker is more recommend for unexperienced users, because you could just copy the `docker-compose.yml`, and do some modify and you good to go!
+In Ubuntu Server, you have two method to deplay RustDesk Server, Docker or nornal `.deb` installation, Docker is more recommend for unexperienced users, because you could just copy the `compose.yml`, and do some modify and you good to go!
 {{% children depth="3" showhidden="true" %}}

--- a/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
@@ -177,7 +177,6 @@ You could modify the line with `hbbs` to your server's LAN IP  temporarily (If y
 Having problem after you changed LAN IP to domain? You should check [this article](/docs/en/self-host/nat-loopback-issues/).
 {{% /notice %}}
 ```yml
-version: '3'
 services:
   hbbs:
     container_name: hbbs

--- a/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
@@ -162,11 +162,11 @@ sudo rm /swap.img
 cd ~ && mkdir -p docker/rustdesk-server/data
 ```
 
-2. Create `docker-compose.yml`
+2. Create `compose.yml`
 
-Right click `rustdesk-server` folder, create new file named `docker-compose.yml`
+Right click `rustdesk-server` folder, create new file named `compose.yml`
 
-Paste this to `docker-compose.yml`.
+Paste this to `compose.yml`.
 
  After you copied, you should replace `rustdesk.example.com` (Which point to your hbbr) to the domain that will point to your server.
 
@@ -238,7 +238,7 @@ Open these required ports:
   * `21118/21119` TCP for web socket if you want to run web client
 
 ## 6. Some basics
-1. How to apply the settings after you modified `docker-compose.yml`?
+1. How to apply the settings after you modified `compose.yml`?
 
 Run this again:
 ```
@@ -264,7 +264,7 @@ Drag and drop them to VSCode Explorer if you want to upload it.
 Use [Watchtower](https://containrrr.dev/watchtower/).
 
 
-Create folder and put the `docker-compose.yml` in it.
+Create folder and put the `compose.yml` in it.
 
 ```
 mkdir ~/docker/watchtower

--- a/content/self-host/rustdesk-server-pro/installscript/Docker/_index.de.md
+++ b/content/self-host/rustdesk-server-pro/installscript/Docker/_index.de.md
@@ -30,7 +30,7 @@ sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v ./data:/root -td --
 
 Mit Docker Compose MÜSSEN Sie `network_mode: "host"` verwenden, um sicherzustellen, dass die Lizenzierung funktioniert. Installieren Sie Docker mit dieser [Anleitung](https://docs.docker.com/engine/install), um sicherzustellen, dass es auf dem neuesten Stand ist!
 
-Kopieren Sie den folgenden Text in die Datei `docker-compose.yml`.
+Kopieren Sie den folgenden Text in die Datei `compose.yml`.
 
 ```yaml
 

--- a/content/self-host/rustdesk-server-pro/installscript/Docker/_index.de.md
+++ b/content/self-host/rustdesk-server-pro/installscript/Docker/_index.de.md
@@ -33,7 +33,6 @@ Mit Docker Compose MÜSSEN Sie `network_mode: "host"` verwenden, um sicherzustel
 Kopieren Sie den folgenden Text in die Datei `docker-compose.yml`.
 
 ```yaml
-version: '3'
 
 services:
   hbbs:

--- a/content/self-host/rustdesk-server-pro/installscript/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/installscript/Docker/_index.en.md
@@ -30,7 +30,7 @@ sudo docker run --name hbbr -p 21117:21117 -p 21119:21119 -v ./data:/root -td --
 
 With Docker Compose you HAVE to use `network_mode: "host"` to ensure licensing works. Install Docker using this [guide](https://docs.docker.com/engine/install) to ensure its the most up to date!
 
-Copy the below into `docker-compose.yml`.
+Copy the below into `compose.yml`.
 
 ```yaml
 

--- a/content/self-host/rustdesk-server-pro/installscript/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/installscript/Docker/_index.en.md
@@ -33,7 +33,6 @@ With Docker Compose you HAVE to use `network_mode: "host"` to ensure licensing w
 Copy the below into `docker-compose.yml`.
 
 ```yaml
-version: '3'
 
 services:
   hbbs:


### PR DESCRIPTION
Hello,

The Version tag for docker-compose.yml is obsolete see https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements


and the filename is the old one now its compose.yml.

i changed both.
renaming is optional