### PR TITLE
Fix small branch 2023.04.15 is outdated

### DIFF
--- a/content/dev/build/windows/_index.en.md
+++ b/content/dev/build/windows/_index.en.md
@@ -26,7 +26,6 @@ If you don't have `Git` installed, get `Git` [here](https://git-scm.com/download
 ```sh
 git clone https://github.com/microsoft/vcpkg
 cd vcpkg
-git checkout 2023.04.15
 cd ..
 vcpkg/bootstrap-vcpkg.bat
 export VCPKG_ROOT=$PWD/vcpkg


### PR DESCRIPTION
Branch of 2023.04.15 is outdated, so remove to fix. If use Branch of 2023.04.15, raise error.