### PR TITLE
Add need for key file in client configuration documentation

### DIFF
--- a/content/self-host/client-configuration/_index.de.md
+++ b/content/self-host/client-configuration/_index.de.md
@@ -39,7 +39,7 @@ hbbs.example.com:21116
 
 #### `Key` festlegen
 
-Um eine verschlüsselte Verbindung zu Ihrem self-hosted Server herzustellen, müssen Sie dessen öffentlichen Schlüssel (Publik Key) eingeben. Der Schlüssel wird normalerweise beim ersten Start von `hbbs` erzeugt und befindet sich in der Datei id_ed25519.pub in Ihrem Arbeitsverzeichnis / Data-Ordner.
+Um eine verschlüsselte Verbindung zu Ihrem self-hosted Server herzustellen, müssen Sie dessen öffentlichen Schlüssel (Publik Key) eingeben. Der Schlüssel wird normalerweise beim ersten Start von `hbbs` erzeugt und befindet sich in der Datei `id_ed25519.pub` in Ihrem Arbeitsverzeichnis / Data-Ordner.
 
 Als `Pro`-Benutzer können Sie den Schlüssel zusätzlich über die [Webkonsole](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/console/) abrufen.
 

--- a/content/self-host/client-configuration/_index.de.md
+++ b/content/self-host/client-configuration/_index.de.md
@@ -39,7 +39,9 @@ hbbs.example.com:21116
 
 #### `Key` festlegen
 
-Als `Pro`-Benutzer können Sie den Schlüssel über die [Webkonsole](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/console/) abrufen. Oder Sie finden ihn in der Datei `id_ed25519.pub` in Ihrem Arbeitsverzeichnis.
+Um eine verschlüsselte Verbindung zu Ihrem self-hosted Server herzustellen, müssen Sie dessen öffentlichen Schlüssel (Publik Key) eingeben. Der Schlüssel wird normalerweise beim ersten Start von `hbbs` erzeugt und befindet sich in der Datei id_ed25519.pub in Ihrem Arbeitsverzeichnis / Data-Ordner.
+
+Als `Pro`-Benutzer können Sie den Schlüssel zusätzlich über die [Webkonsole](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/console/) abrufen.
 
 ![](/docs/en/self-host/rustdesk-server-pro/console/images/console-home.png?v2)
 

--- a/content/self-host/client-configuration/_index.en.md
+++ b/content/self-host/client-configuration/_index.en.md
@@ -39,7 +39,9 @@ hbbs.example.com:21116
 
 #### Set `Key`
 
-As a `Pro` user you will be able to retrieve the `Key` from the [web console](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/console/), or you can find it in `id_ed25519.pub` file under your working directory.
+In order to establish an encrypted connection to your self-hosted server, you need to enter its public key. The key is usualy generated on the first run of `hbbs` and can be found in the file `id_ed25519.pub` in your working directory / data folder.
+
+As a `Pro` user you will additionally be able to retrieve the `Key` from the [web console](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/console/).
 
 ![](/docs/en/self-host/rustdesk-server-pro/console/images/console-home.png?v2)
 

--- a/content/self-host/client-configuration/_index.pt.md
+++ b/content/self-host/client-configuration/_index.pt.md
@@ -34,7 +34,10 @@ hbbs.example.com:21116
 ```
 
 #### Defina a `Key`
-Como usuário `Pro`, você poderá recuperar a `Key` no [console web](https://rustdesk.com/docs/pt/self-host/rustdesk-server-pro/console/) ou encontrá-la no arquivo `id_ed25519.pub` em seu diretório de trabalho.
+
+Para estabelecer uma ligação encriptada ao seu servidor auto-hospedado, é necessário introduzir a sua chave pública. A chave é normalmente gerada na primeira execução do `hbbs` e pode ser encontrada no ficheiro `id_ed25519.pub` no seu diretório de trabalho / pasta de dados.
+
+Como utilizador `Pro`, poderá também obter a `Key` a partir da [console web](https://rustdesk.com/docs/pt/self-host/rustdesk-server-pro/console/).
 
 ![](/docs/en/self-host/rustdesk-server-pro/console/images/console-home.png?v2)
 


### PR DESCRIPTION
Since it is now necessary to add the key, I added the respecting paragraphs in the configuration files.