### PR TITLE
Fix a few typos in documentation

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -5,7 +5,7 @@ weight: 1
 
 # RustDesk Documentation
 
-RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration. You have full control of your data, with no concerns about security. The Client is open source and theres a choice between the fully featured **Professional Server** available to purchase on our [website](https://rustdesk.com) and the basic free and OSS Server based on our **Professional Server**.
+RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration. You have full control of your data, with no concerns about security. The Client is open source and there's a choice between the fully featured **Professional Server** available to purchase on our [website](https://rustdesk.com) and the basic free and OSS Server based on our **Professional Server**.
 
 ### Features
 - Works on Windows, macOS, Linux, iOS, Android, Web.

--- a/content/self-host/rustdesk-server-oss/Docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/Docker/_index.en.md
@@ -6,7 +6,7 @@ weight: 7
 ### Install your own server with Docker
 
 #### Requirements
-You need to have Docker/Podman installed to run a rustdesk-server as a Docker container, if in doubt install Docker with this [guide](https://docs.docker.com/engine/install) to ensure its the most up to date!
+You need to have Docker/Podman installed to run a rustdesk-server as a Docker container. If in doubt, install Docker with this [guide](https://docs.docker.com/engine/install) to ensure it's the most up to date!
 
 By default, `hbbs` listens on 21114 (TCP, for web console, only available in Pro version), 21115 (TCP), 21116 (TCP/UDP) and 21118 (TCP), `hbbr` listens on 21117 (TCP) and 21119 (TCP). Be sure to open these ports in the firewall. **Please note that 21116 should be enabled both for TCP and UDP.** 21115 is used for the NAT type test, 21116/UDP is used for the ID registration and heartbeat service, 21116/TCP is used for TCP hole punching and connection service, 21117 is used for the Relay services, and 21118 and 21119 are used to support web clients. *If you do not need web client (21118, 21119) support, the corresponding ports can be disabled.*
 
@@ -30,7 +30,7 @@ If `--net=host` works fine, the `-p` options are not used. If on Windows, leave 
 {{% /notice %}}
 
 {{% notice note %}}
-If you can not see logs with `-td`, you can see logs via `docker logs hbbs`. Or you can run with `-it`, `hbbs/hbbr` will not run as daemon mode.
+If you cannot see logs with `-td`, you can see logs via `docker logs hbbs`. Or you can run with `-it`, `hbbs/hbbr` will not run as daemon mode.
 {{% /notice %}}
 
 #### Docker Compose examples

--- a/content/self-host/rustdesk-server-oss/install/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.en.md
@@ -17,7 +17,7 @@ You need to have Linux installed, script is tested working with CentOS Linux 7/8
 ##### How to Install the server
 Please setup your firewall on your server prior to running the script.
 
-Make sure you have got access via SSH or otherwise setup prior setting up the firewall. The example commands for UFW (Debian based) are:
+Make sure you have got access via SSH or otherwise setup prior to setting up the firewall. The example commands for UFW (Debian based) are:
 ```
 ufw allow proto tcp from YOURIP to any port 22
 ```

--- a/content/self-host/rustdesk-server-oss/synology/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/synology/_index.en.md
@@ -3,8 +3,8 @@ title: Synology
 weight: 22
 ---
 
-Synology has two types of Docker, "Docker" and "Container Manager". If you're using DSM 7.2 and later, please follow the guide for DSM 7.2, or follow the DSM 6 guide if you're on older system.
+Synology has two types of Docker, "Docker" and "Container Manager". If you're using DSM 7.2 and later, please follow the guide for DSM 7.2, or follow the DSM 6 guide if you're on an older system.
 
-If you are using Synology with Portainer, please check [this tutorial](https://mariushosting.com/how-to-install-rustdesk-on-your-synology-nas/).
+If you are using Synology with Portainer, please refer to [this tutorial](https://mariushosting.com/how-to-install-rustdesk-on-your-synology-nas/).
 
 {{% children depth="3" showhidden="true" %}}


### PR DESCRIPTION
I was reading through some of the docs and noticed a few typos. Hope this is a welcome change.