### PR TITLE
Update _index.en.md

### DIFF
--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -210,14 +210,8 @@ rustdesk_cfg="configstring"
 
 ################################### Please Do Not Edit Below This Line #########################################
 
-# Check if the script is being run as root
-if [[ $EUID -ne 0 ]]; then
-    echo "This script must be run as root."
-    exit 1
-fi
-
-# Specify the path to the rustdesk.dmg file
-dmg_file="/tmp/rustdesk-1.2.6-x86_64.dmg"
+# Root password request for privilege escalation
+[ "$UID" -eq 0 ] || exec sudo bash "$0" "$@"
 
 # Specify the mount point for the DMG (temporary directory)
 mount_point="/Volumes/RustDesk"
@@ -226,9 +220,13 @@ mount_point="/Volumes/RustDesk"
 echo "Downloading RustDesk Now"
 
 if [[ $(arch) == 'arm64' ]]; then
-    curl -L https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-aarch64.dmg --output "$dmg_file"
+    rd_link=$(curl -sL https://github.com/rustdesk/rustdesk/releases/latest | grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*/\d{1}.\d{1,2}.\d{1,2}/rustdesk.\d{1}.\d{1,2}.\d{1,2}.aarch64.dmg")
+    dmg_file=$(echo $rd_link | grep -Eo "rustdesk.\d{1}.\d{1,2}.\d{1,2}.aarch64.dmg")
+    curl -L "$rd_link" --output "$dmg_file"
 else
-    curl -L https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.dmg --output "$dmg_file"
+    rd_link=$(curl -sL https://github.com/rustdesk/rustdesk/releases/latest | grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*/\d{1}.\d{1,2}.\d{1,2}/rustdesk.\d{1}.\d{1,2}.\d{1,2}.x86_64.dmg")
+    dmg_file=$(echo $rd_link | grep -Eo "rustdesk.\d{1}.\d{1,2}.\d{1,2}.x86_64.dmg")
+    curl -L "$rd_link" --output "$dmg_file"
 fi
 
 # Mount the DMG file to the specified mount point


### PR DESCRIPTION
Bash script for macOS will now be able to automatically get the latest version from github. 
Notification about need for root privileges has been replaced with a request for root password to execute script.