### PR TITLE
docker build: limit git history

### DIFF
--- a/content/dev/build/docker/_index.en.md
+++ b/content/dev/build/docker/_index.en.md
@@ -9,7 +9,7 @@ weight: 30
 Begin by cloning the repository and building the Docker container:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --depth=1 https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```


### PR DESCRIPTION
Limit the git history to the latest state which ist enugh for that use case. Saves some resources and time on both sides.