### PR TITLE
No port forwarding on websocket port; remove `hbbs -r` related notice; several WebSocket/Web Client related

### DIFF
--- a/content/self-host/_index.en.md
+++ b/content/self-host/_index.en.md
@@ -45,7 +45,7 @@ UDP `21116`
 
 The above `21115-21117` are the minimum required ports for RustDesk to work, these handle the signal and relay ports as well as NAT traversal.
 
-Additionally TCP ports `21118` and `21119` can be opened if you want to use the [RustDesk Web Client](https://rustdesk.com/docs/en/dev/build/web/).
+TCP ports `21118` and `21119` are the WebSocket ports for the [RustDesk Web Client](https://rustdesk.com/web/), but it won't works if you open them, it needs a reverse proxy to make it support HTTPS, please refer this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
 
 For Pro users without an SSL Proxy you will need to open TCP port `21114` for the API to work alternatively using an SSL Proxy open TCP port `443`.
 

--- a/content/self-host/_index.en.md
+++ b/content/self-host/_index.en.md
@@ -45,7 +45,7 @@ UDP `21116`
 
 The above `21115-21117` are the minimum required ports for RustDesk to work, these handle the signal and relay ports as well as NAT traversal.
 
-TCP ports `21118` and `21119` are the WebSocket ports for the [RustDesk Web Client](https://rustdesk.com/web/), but it won't works if you open them, it needs a reverse proxy to make it support HTTPS, please refer this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+TCP ports `21118` and `21119` are the WebSocket ports for the [RustDesk Web Client](https://rustdesk.com/web/), you need a reverse proxy to make it support HTTPS, please refer this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
 
 For Pro users without an SSL Proxy you will need to open TCP port `21114` for the API to work alternatively using an SSL Proxy open TCP port `443`.
 

--- a/content/self-host/rustdesk-server-oss/install/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/install/_index.en.md
@@ -99,7 +99,7 @@ PM2 requires Node.js v16+, if you fail to run PM2 (e.g. you can not see `hbbs`/`
 
 #### Ports
 
-By default, `hbbs` listens on 21114 (TCP, for web console, only available in Pro version), 21115 (TCP), 21116 (TCP/UDP) and 21118 (TCP), `hbbr` listens on 21117 (TCP) and 21119 (TCP). Be sure to open these ports in the firewall. **Please note that 21116 should be enabled both for TCP and UDP.** 21115 is used for the NAT type test and online status query, 21116/UDP is used for the ID registration and heartbeat service, 21116/TCP is used for TCP hole punching and connection service, 21117 is used for the Relay services, and 21118 and 21119 are used to support web clients. *If you do not need web client (21118, 21119) support, the corresponding ports can be disabled.*
+By default, `hbbs` listens on 21114 (TCP, for web console, only available in Pro version), 21115 (TCP), 21116 (TCP/UDP) and 21118 (TCP), `hbbr` listens on 21117 (TCP) and 21119 (TCP). Be sure to open these ports in the firewall. **Please note that 21116 should be enabled both for TCP and UDP.** 21115 is used for the NAT type test and online status query, 21116/UDP is used for the ID registration and heartbeat service, 21116/TCP is used for TCP hole punching and connection service, 21117 is used for the Relay services, and 21118 and 21119 are used to support web clients, please refer this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client) if you want to use web client. *If you do not need web client (21118, 21119) support, the corresponding ports can be disabled.*
 
 - TCP (**21114, 21115, 21116, 21117, 21118, 21119**)
 - UDP (**21116**)

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
@@ -30,10 +30,6 @@ Nach der Installation von "Container Manager" wird ein gemeinsamer Ordner `docke
 
 Geben Sie den Projektnamen `rustdesk-server` ein, ändern Sie Source von "Upload compose.yml" zu "Create compose.yml" und kopieren Sie den folgenden Inhalt in das Feld. 
 
-{{% notice note %}}
-Sie könnten die Zeile mit `hbbs` vorübergehend in die LAN-IP Ihres NAS ändern, wie auf dem Bild gelb markiert zu sehen. Nachdem Sie sich vergewissert haben, dass Ihr Server funktioniert, **sollten** Sie die Änderung zurücknehmen.
-{{% /notice %}}
-
 ![](images/dsm7_creating_project_init.png?v2)
 
 ```yaml

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.de.md
@@ -65,7 +65,6 @@ services:
 # 21116 TCP TCP hole punching
 # 21116 UDP Heartbeat/ID-Server
 # 21117 TCP Relay
-# 21118/21119 TCP für Websocket, wenn Sie einen Webclient betreiben wollen
 ```
 
 Bitte überspringen Sie `Web portal settings`, dann ist das erledigt.
@@ -109,4 +108,3 @@ Wenn Sie die Einstellung immer noch nicht finden können, suchen Sie in Google n
   * `21116` TCP TCP hole punching
   * `21116` UDP Heartbeat/ID-Server
   * `21117` TCP Relay
-  * `21118/21119` TCP für Websocket, wenn Sie einen Webclient betreiben wollen

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
@@ -30,10 +30,6 @@ Open your Container Manager, go to Project and click Create.
 
 Enter the project name `rustdesk-server` and change Source from "Upload compose.yml" to "Create compose.yml", and copy following contents to the box.
 
-{{% notice note %}}
-You could modify the line with `hbbs` to your NAS's LAN IP temporarily just like the picture. After you verify your server is working, you **should** change back.
-{{% /notice %}}
-
 ![](images/dsm7_creating_project_init.png?v2)
 
 ```yaml

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.en.md
@@ -65,7 +65,6 @@ services:
 # 21116 TCP TCP hole punching
 # 21116 UDP heartbeat/ID server
 # 21117 TCP relay
-# 21118/21119 TCP for web socket if you want to run web client
 ```
 
 Please skip `Web portal settings` then done.
@@ -109,4 +108,3 @@ Open these required ports:
   * `21116` TCP TCP hole punching
   * `21116` UDP heartbeat/ID server
   * `21117` TCP relay
-  * `21118/21119` TCP for web socket if you want to run web client

--- a/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-oss/synology/dsm-7/_index.zh-tw.md
@@ -28,10 +28,6 @@ Container Manager 為部分低階的 ARM64 的機型帶來支援，例如 j 系�
 
 輸入您的專案名稱 `rustdesk-server` 然後變更來源從"上傳 compose.yml" 至 "建立 compose.yml"，接著複製下方內容到框框。
 
-{{% notice note %}}
-如圖所示，您可以暫時將 `hbbs` 那行改為指向至您的NAS的 LAN IP，在您驗證您的伺服器可以正常運作後，您**應當**變更回來。
-{{% /notice %}}
-
 ![](images/dsm7_creating_project_init.png?v2)
 
 ````yaml

--- a/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.de.md
+++ b/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.de.md
@@ -214,7 +214,6 @@ services:
 # 21116 TCP TCP hole punching
 # 21116 UDP heartbeat/ID server
 # 21117 TCP relay
-# 21118/21119 TCP für Websocket, wenn Sie einen Webclient betreiben wollen
 ```
 Lesen Sie [hier](/docs/de/client), wie Sie Ihren Client einrichten. Nur `ID-Server` und `Key` werden benötigt. `Relais-Server` wird nicht benötigt, da wir ihn in `hbbs` festgelegt haben. Diese Informationen werden von `hbbs` automatisch bereitgestellt.
 
@@ -245,7 +244,6 @@ Wenn Sie einen VPS verwenden, suchen Sie mit Google nach `Name des VPS-Anbieters
   * `21116` TCP TCP hole punching
   * `21116` UDP Heartbeat/ID-Server
   * `21117` TCP Relay
-  * `21118/21119` TCP für Websocket, wenn Sie einen Webclient betreiben wollen
 
 ### 5. Einige Grundlagen
 

--- a/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
+++ b/content/self-host/rustdesk-server-oss/ubuntu-server/docker/_index.en.md
@@ -214,7 +214,6 @@ services:
 # 21116 TCP TCP hole punching
 # 21116 UDP heartbeat/ID server
 # 21117 TCP relay
-# 21118/21119 TCP for web socket if you want to run web client
 ```
 Check [here](/docs/en/client) to set up your client. Only `ID server` and `Key` is needed. `Relay server` isn't needed because we've set it in `hbbs`, hbbs will provide this information automatically.
 
@@ -245,7 +244,6 @@ Open these required ports:
   * `21116` TCP TCP hole punching
   * `21116` UDP heartbeat/ID server
   * `21117` TCP relay
-  * `21118/21119` TCP for web socket if you want to run web client
 
 ### 5. Some basics
 


### PR DESCRIPTION
* No port forwarding on WebSocket port, because it can't be directly used, it needs reverse proxy
* Remove `hbbs -r` related notice: Now, `-r` has removed, having this will confuse users
* Provide  shortcut to sample Nginx configuration