### PR TITLE
Don't create 'null' files on Windows

### DIFF
--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -89,7 +89,7 @@ if ($rdver -eq $RustDeskOnGitHub.Version)
 
 if (!(Test-Path C:\Temp))
 {
-    New-Item -ItemType Directory -Force -Path C:\Temp > null
+    New-Item -ItemType Directory -Force -Path C:\Temp | Out-Null
 }
 
 cd C:\Temp


### PR DESCRIPTION
Suppressing emitted STDOUT from cmdlets is done with by piping to `Out-Null` instead of redirecting to `null`. That last option will create a new file on Windows.

This pull request fixes this mistake in the default installer script on the documentation page.

```
# Don't do ❌
mkdir test > null

# Do ✅
mkdir test | Out-Null
```