### PR TITLE
Fix powershell invalid operation on NULL

### DIFF
--- a/content/self-host/client-deployment/_index.de.md
+++ b/content/self-host/client-deployment/_index.de.md
@@ -105,6 +105,7 @@ if ($arrService -eq $null)
     cd $env:ProgramFiles\RustDesk
     Start-Process .\rustdesk.exe --install-service
     Start-Sleep -seconds 20
+    $arrService = Get-Service -Name $ServiceName
 }
 
 while ($arrService.Status -ne 'Running')

--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -107,6 +107,7 @@ if ($arrService -eq $null)
     cd $env:ProgramFiles\RustDesk
     Start-Process .\rustdesk.exe --install-service
     Start-Sleep -seconds 20
+    $arrService = Get-Service -Name $ServiceName
 }
 
 while ($arrService.Status -ne 'Running')

--- a/content/self-host/client-deployment/_index.pt.md
+++ b/content/self-host/client-deployment/_index.pt.md
@@ -107,6 +107,7 @@ if ($arrService -eq $null)
     cd $env:ProgramFiles\RustDesk
     Start-Process .\rustdesk.exe --install-service
     Start-Sleep -seconds 20
+    $arrService = Get-Service -Name $ServiceName
 }
 
 while ($arrService.Status -ne 'Running')

--- a/content/self-host/client-deployment/_index.tr.md
+++ b/content/self-host/client-deployment/_index.tr.md
@@ -104,6 +104,7 @@ if ($arrService -eq $null)
     cd $env:ProgramFiles\RustDesk
     Start-Process .\rustdesk.exe --install-service
     Start-Sleep -seconds 20
+    $arrService = Get-Service -Name $ServiceName
 }
 
 while ($arrService.Status -ne 'Running')


### PR DESCRIPTION
**Szenario**
Install rustdesk on a clean windows client by using the powershell client deployment script.

**Current behavior**
No config and password will be set.
On a clean windows machine, the script fails because no rustdesk service exists yet. After the installation the `$arrService` variable is not reassigned and still `NULL`.

https://github.com/rustdesk/rustdesk/issues/10456

**Expected behavior**
Install rustdesk with configuration and password options.