### PR TITLE
Update _index.en.md to indicate c++ redist prereq

### DIFF
--- a/content/self-host/rustdesk-server-pro/installscript/windows/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/installscript/windows/_index.en.md
@@ -13,6 +13,9 @@ The GUI version, `RustDeskServer.setup.exe` has not been maintained any more, no
 
 ### Install
 
+## Pre-Requisite
+The Microsoft Visual C++ Redistributable is required to run rustdesk on Windows. You can download it [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
+
 1. Get your license from [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), check [license](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) page for more details.
 2. Download the the Windows installer from [GitHub](https://github.com/rustdesk/rustdesk-server-pro/releases/latest).
 3. Unzip the Windows installer.


### PR DESCRIPTION
If the c++ redistributable isn't installed, the start service shell fails silently and nothing helpful is logged. This is frustrating and there's no reason it isn't listed on the read me, especially since it has been acknowledged by the maintainer. 

It would have taken very little effort beyond the sassy comment [here](https://github.com/rustdesk/rustdesk-server/issues/163#issuecomment-1386420173) to actually address this.