### PR TITLE
Fix: Ensure submodules are cloned by adding --recurse-submodules to docs

### DIFF
--- a/content/dev/build/linux/_index.en.md
+++ b/content/dev/build/linux/_index.en.md
@@ -26,7 +26,7 @@ sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-c
 #### Install vcpkg
 
 ```sh
-git clone https://github.com/microsoft/vcpkg
+git clone --recurse-submodules https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 2023.10.19
 cd ..


### PR DESCRIPTION
This update improves the documentation by adding the --recurse-submodules flag to the git clone command. Since the repository contains multiple submodules, cloning without this flag would result in missing dependencies, potentially causing build or runtime issues. This change ensures that all submodules are fetched and initialized correctly, streamlining the setup process for contributors.