### PR TITLE
Docs: Fix git clone command in all language versions

### DIFF
--- a/content/dev/build/docker/_index.de.md
+++ b/content/dev/build/docker/_index.de.md
@@ -9,7 +9,7 @@ weight: 30
 Beginnen Sie mit dem Klonen des Repositorys und der Erstellung des Docker-Containers:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.es.md
+++ b/content/dev/build/docker/_index.es.md
@@ -9,7 +9,7 @@ weight: 30
 Comience clonando el repositorio y construyendo el contenedor docker:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.fr.md
+++ b/content/dev/build/docker/_index.fr.md
@@ -8,7 +8,7 @@ weight: 30
 Commencez par cloner le dépôt et construire le conteneur Docker :
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.it.md
+++ b/content/dev/build/docker/_index.it.md
@@ -8,7 +8,7 @@ weight: 30
 Cominciare clonando il repository e compilare i container docker:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.ja.md
+++ b/content/dev/build/docker/_index.ja.md
@@ -8,7 +8,7 @@ weight: 30
 リポジトリのクローンを作成し、Dockerコンテナを構築することから始めます。
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.nl.md
+++ b/content/dev/build/docker/_index.nl.md
@@ -10,7 +10,7 @@ weight: 30
 Begin met het klonen van de repository en build de docker container:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.pt.md
+++ b/content/dev/build/docker/_index.pt.md
@@ -8,7 +8,7 @@ weight: 30
 Comece clonando o repositório e montando o container docker:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.ru.md
+++ b/content/dev/build/docker/_index.ru.md
@@ -8,7 +8,7 @@ weight: 30
 Начните с клонирования репозитория и создания docker контейнера:
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.zh-cn.md
+++ b/content/dev/build/docker/_index.zh-cn.md
@@ -8,7 +8,7 @@ weight: 30
 首先克隆存储库并构建 docker 容器：
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/docker/_index.zh-tw.md
+++ b/content/dev/build/docker/_index.zh-tw.md
@@ -8,7 +8,7 @@ weight: 30
 首先克隆存儲庫並構建 docker 容器：
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```

--- a/content/dev/build/ios/_index.de.md
+++ b/content/dev/build/ios/_index.de.md
@@ -8,7 +8,7 @@ cd
 # Um Ihre und unsere Zeit zu sparen, haben wir abhängige Dateien für Sie vorbereitet.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # Für den Simulator: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.en.md
+++ b/content/dev/build/ios/_index.en.md
@@ -8,7 +8,7 @@ cd
 # For saving your time and our time, we prepared dependent files for you.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # For simulator: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.es.md
+++ b/content/dev/build/ios/_index.es.md
@@ -8,7 +8,7 @@ cd
 # Para ahorrar su tiempo y el nuestro, preparamos archivos dependientes para usted.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # Para simulador: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.fr.md
+++ b/content/dev/build/ios/_index.fr.md
@@ -8,7 +8,7 @@ cd
 # Pour économiser votre temps et le nôtre, nous avons préparé pour vous les dépendances.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # Pour la simulation: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.nl.md
+++ b/content/dev/build/ios/_index.nl.md
@@ -8,7 +8,7 @@ cd
 # For saving your time and our time, we prepared dependent files for you.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # For simulator: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.ru.md
+++ b/content/dev/build/ios/_index.ru.md
@@ -8,7 +8,7 @@ cd
 # Для экономии вашего и нашего времени мы подготовили для вас файлы зависимостей.
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # Для симулятора: VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/ios/_index.zh-tw.md
+++ b/content/dev/build/ios/_index.zh-tw.md
@@ -8,7 +8,7 @@ cd
 # 為節省你我的時間，我們已經準備好依賴檔案了。
 https://github.com/rustdesk/doc.rustdesk.com/releases/download/console/ios_dep.tar.gz
 tar xzf ios_dep.tar.gz
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 # 模擬器：VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_x64.sh
 VCPKG_ROOT=$HOME/vcpkg ./flutter/ios_arm64.sh

--- a/content/dev/build/linux/_index.de.md
+++ b/content/dev/build/linux/_index.de.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone  https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.en.md
+++ b/content/dev/build/linux/_index.en.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.es.md
+++ b/content/dev/build/linux/_index.es.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.fr.md
+++ b/content/dev/build/linux/_index.fr.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.it.md
+++ b/content/dev/build/linux/_index.it.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.ja.md
+++ b/content/dev/build/linux/_index.ja.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.nl.md
+++ b/content/dev/build/linux/_index.nl.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.pt.md
+++ b/content/dev/build/linux/_index.pt.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.ru.md
+++ b/content/dev/build/linux/_index.ru.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.zh-cn.md
+++ b/content/dev/build/linux/_index.zh-cn.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/linux/_index.zh-tw.md
+++ b/content/dev/build/linux/_index.zh-tw.md
@@ -53,7 +53,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so

--- a/content/dev/build/osx/_index.de.md
+++ b/content/dev/build/osx/_index.de.md
@@ -50,7 +50,7 @@ Für einen Überblick über die installierten und standardmäßigen Rust-Toolcha
 Entscheiden Sie, wo Sie die RustDesk-Quelldateien haben möchten, und führen Sie den folgenden Befehl in dem Ordner aus, in dem sich der Ordner `rustdesk` befinden soll. In diesem Beispiel wird `/Users/<Benutzername>/repos/` als Speicherort verwendet.
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk/libs/portable/
 python3 -m pip install --upgrade pip
 pip3 install -r requirements.txt

--- a/content/dev/build/osx/_index.en.md
+++ b/content/dev/build/osx/_index.en.md
@@ -50,7 +50,7 @@ For an overview over installed and default Rust toolchains, run `rustup show`.
 Decide where you want the RustDesk source files and run the following from the folder in which you want the `rustdesk` folder to reside. In this example `/Users/<username>/repos/` is used as the location.
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk/libs/portable/
 python3 -m pip install --upgrade pip
 pip3 install -r requirements.txt

--- a/content/dev/build/osx/_index.es.md
+++ b/content/dev/build/osx/_index.es.md
@@ -11,7 +11,7 @@ git checkout 2023.04.15
 ./bootstrap-vcpkg.sh
 brew install nasm yasm
 ./vcpkg install libvpx libyuv opus aom
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 export VCPKG_ROOT=$HOME/vcpkg
 cargo run

--- a/content/dev/build/osx/_index.fr.md
+++ b/content/dev/build/osx/_index.fr.md
@@ -11,7 +11,7 @@ git checkout 2023.04.15
 ./bootstrap-vcpkg.sh
 brew install nasm yasm
 ./vcpkg install libvpx libyuv opus aom
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 export VCPKG_ROOT=$HOME/vcpkg
 wget https://github.com/c-smile/sciter-sdk/raw/master/bin.osx/libsciter.dylib

--- a/content/dev/build/osx/_index.nl.md
+++ b/content/dev/build/osx/_index.nl.md
@@ -11,7 +11,7 @@ git checkout 2023.04.15
 ./bootstrap-vcpkg.sh
 brew install nasm yasm
 ./vcpkg install libvpx libyuv opus aom
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 export VCPKG_ROOT=$HOME/vcpkg
 wget https://github.com/c-smile/sciter-sdk/raw/master/bin.osx/libsciter.dylib

--- a/content/dev/build/osx/_index.zh-tw.md
+++ b/content/dev/build/osx/_index.zh-tw.md
@@ -11,7 +11,7 @@ git checkout 2023.04.15
 ./bootstrap-vcpkg.sh
 brew install nasm yasm
 ./vcpkg install libvpx libyuv opus aom
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 export VCPKG_ROOT=$HOME/vcpkg
 wget https://github.com/c-smile/sciter-sdk/raw/master/bin.osx/libsciter.dylib

--- a/content/dev/build/windows/_index.de.md
+++ b/content/dev/build/windows/_index.de.md
@@ -52,7 +52,7 @@ Sie können die Version 15.0.2 der LLVM-Binärdateien hier herunterladen: [64 Bi
 #### Standard
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll

--- a/content/dev/build/windows/_index.en.md
+++ b/content/dev/build/windows/_index.en.md
@@ -24,7 +24,7 @@ Go to the folder you want to clone vcpkg and use [Git Bash](https://git-scm.com/
 If you don't have `Git` installed, get `Git` [here](https://git-scm.com/download/win).
 
 ```sh
-git clone --recurse-submodules https://github.com/microsoft/vcpkg
+git clone https://github.com/microsoft/vcpkg
 vcpkg/bootstrap-vcpkg.bat
 export VCPKG_ROOT=$PWD/vcpkg
 vcpkg/vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static aom:x64-windows-static
@@ -49,7 +49,7 @@ You can download version 15.0.2 of the LLVM binaries here: [64 bit](https://gith
 #### Default
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll

--- a/content/dev/build/windows/_index.es.md
+++ b/content/dev/build/windows/_index.es.md
@@ -46,7 +46,7 @@ rust-bindgen depende del clang, descargar [llvm](https://github.com/llvm/llvm-pr
 ### Por defecto
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 mv sciter.dll target/debug

--- a/content/dev/build/windows/_index.fr.md
+++ b/content/dev/build/windows/_index.fr.md
@@ -50,7 +50,7 @@ Vous pouvez télécharger LLVM 15.02 ici : [64-bit](https://github.com/llvm/llvm
 ## Compilation
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll

--- a/content/dev/build/windows/_index.nl.md
+++ b/content/dev/build/windows/_index.nl.md
@@ -52,7 +52,7 @@ U kunt 15.02 van de LLVM-binaire bestanden hier downloaden: [64-bit](https://git
 ### Standaard
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll

--- a/content/dev/build/windows/_index.pt.md
+++ b/content/dev/build/windows/_index.pt.md
@@ -49,7 +49,7 @@ Você pode baixar a versão 15.0.2 dos binários do LLVM aqui: [64 bits](https:/
 #### Padrão
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll

--- a/content/dev/build/windows/_index.ru.md
+++ b/content/dev/build/windows/_index.ru.md
@@ -42,7 +42,7 @@ rust-bindgen зависит от clang, скачайте и установите
 ## Сборка
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 mv sciter.dll target/debug

--- a/content/dev/build/windows/_index.zh-cn.md
+++ b/content/dev/build/windows/_index.zh-cn.md
@@ -43,7 +43,7 @@ rust-bindgen依赖于clang, 下载[llvm](https://github.com/llvm/llvm-project/re
 ## 构建
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 mv sciter.dll target/debug

--- a/content/dev/build/windows/_index.zh-tw.md
+++ b/content/dev/build/windows/_index.zh-tw.md
@@ -51,7 +51,7 @@ rust-bindgen 依賴 clang，下載 [llvm](https://github.com/llvm/llvm-project/r
 ### 預設
 
 ```sh
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll


### PR DESCRIPTION
Updated the documentation across all language versions to include the --recurse-submodules flag in the git clone command. This ensures that submodules are properly cloned, preventing potential setup issues. This change maintains consistency across different translations and improves the onboarding experience for contributors.