### PR TITLE
Provided detailed commands to backup and upgrade Rustdesk

### DIFF
--- a/content/self-host/rustdesk-server-pro/faq/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.en.md
@@ -35,7 +35,7 @@ You'd better back up data files (sqlite3 files etc.) first, https://github.com/r
 #### Docker Compose
 ```
 tar -czvf "RustdeskDB$(date +'%Y%m%d%H%M%S').tar.gz" /path/to/your/data
-docker kill hbbr hbbs                        # Stop the running containers
+docker stop hbbr hbbs                        # Stop the running containers
 docker rm hbbr hbbs                          # Remove the stopped containers
 docker rmi rustdesk/rustdesk-server-pro      # Remove the current RustDesk image
 docker image prune -f                        # Clean up any unused, untagged images (this will clear out _every_ unused or untagged docker image on the system, without asking!)

--- a/content/self-host/rustdesk-server-pro/faq/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.en.md
@@ -34,7 +34,12 @@ You'd better back up data files (sqlite3 files etc.) first, https://github.com/r
 3. Follow the prompts as they guide you through the upgrade.
 #### Docker Compose
 ```
-docker compose up -d --build --pull always
+tar -czvf "RustdeskDB$(date +'%Y%m%d%H%M%S').tar.gz" /path/to/your/data
+docker kill hbbr hbbs                        # Stop the running containers
+docker rm hbbr hbbs                          # Remove the stopped containers
+docker rmi rustdesk/rustdesk-server-pro      # Remove the current RustDesk image
+docker image prune -f                        # Clean up any unused, untagged images (this will clear out _every_ unused or untagged docker image on the system, without asking!)
+docker compose up -d --build --pull always   # Pull and rebuild the latest image
 ```
 But this depends on your docker version, for more discussion, check [this](https://stackoverflow.com/questions/37685581/how-to-get-docker-compose-to-use-the-latest-image-from-repository).
 #### Docker


### PR DESCRIPTION
I expanded on the commands to provide more detailed instructions on how to perform a backup of Rustdesk as well as bringing down the docker containers, removing the containers, removing the images, pruning any unused images, and finally pulling and bringing back up a fresh image of Rustdesk docker container.