### PR TITLE
update advanced options allow-logon-screen-password

### DIFF
--- a/content/self-host/client-configuration/advanced-settings/_index.de.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.de.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Ob Passworteingabe auf dem Anmeldebildschirm erlaubt ist, wenn [Nur-Klick-Genehmigungsmodus](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) verwendet wird, verfügbar in RustDesk-Client >=1.3.1 (gesteuerte Seite)
 
-Wenn aktiviert, ist das permanente Passwort auch zulässig, wenn sich die aktuelle Windows-Sitzung im Anmelde- oder Sperrbildschirmstatus befindet. RustDesk client >=1.4.7 (controlled side)
+Wenn aktiviert, ist das permanente Passwort auch zulässig, wenn sich die aktuelle Sitzung im Anmelde- oder Sperrbildschirmstatus befindet. Dies gilt für die Genehmigungsmodi Click, Password und Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.de.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.de.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Ob Passworteingabe auf dem Anmeldebildschirm erlaubt ist, wenn [Nur-Klick-Genehmigungsmodus](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) verwendet wird, verfügbar in RustDesk-Client >=1.3.1 (gesteuerte Seite)
 
-Wenn aktiviert, ist das permanente Passwort auch zulässig, wenn sich die aktuelle Sitzung im Anmelde- oder Sperrbildschirmstatus befindet. Dies gilt für die Genehmigungsmodi Click, Password und Both. RustDesk client >=1.4.7 (controlled side)
+Wenn aktiviert, ist das permanente Passwort auch zulässig, wenn sich die aktuelle Sitzung im Anmelde- oder Sperrbildschirmstatus befindet. Dies gilt für die Genehmigungsmodi Click, Password und Both. Verfügbar in RustDesk-Client >=1.4.7 (gesteuerte Seite)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.en.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.en.md
@@ -1329,7 +1329,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 If allow password input on logon screen when [click-only approve mode](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) is used, available in RustDesk client >=1.3.1 (controlled side)
 
-When enabled, permanent password is also allowed when the current Windows session is in a logon or lock-screen state. RustDesk client >=1.4.7 (controlled side)
+When enabled, permanent password is also allowed when the current session is in a logon or lock-screen state. This applies to Click, Password, and Both approve modes. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.es.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.es.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Si permitir entrada de contraseña en pantalla de inicio de sesión cuando se usa [modo de aprobación solo clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponible en cliente RustDesk >=1.3.1 (lado controlado)
 
-Cuando está habilitado, también se permite la contraseña permanente cuando la sesión actual de Windows está en un estado de inicio de sesión o de pantalla bloqueada. RustDesk client >=1.4.7 (controlled side)
+Cuando está habilitado, también se permite la contraseña permanente cuando la sesión actual está en un estado de inicio de sesión o de pantalla bloqueada. Esto se aplica a los modos de aprobación Click, Password y Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.es.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.es.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Si permitir entrada de contraseña en pantalla de inicio de sesión cuando se usa [modo de aprobación solo clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponible en cliente RustDesk >=1.3.1 (lado controlado)
 
-Cuando está habilitado, también se permite la contraseña permanente cuando la sesión actual está en un estado de inicio de sesión o de pantalla bloqueada. Esto se aplica a los modos de aprobación Click, Password y Both. RustDesk client >=1.4.7 (controlled side)
+Cuando está habilitado, también se permite la contraseña permanente cuando la sesión actual está en un estado de inicio de sesión o de pantalla bloqueada. Esto se aplica a los modos de aprobación Click, Password y Both. Disponible en cliente RustDesk >=1.4.7 (lado controlado)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.fr.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.fr.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Si permettre la saisie de mot de passe sur l'écran de connexion quand le [mode d'approbation par clic uniquement](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) est utilisé, disponible dans le client RustDesk >=1.3.1 (côté contrôlé)
 
-Lorsqu'elle est activée, le mot de passe permanent est également autorisé lorsque la session actuelle est sur un écran de connexion ou de verrouillage. Cela s'applique aux modes d'approbation Click, Password et Both. RustDesk client >=1.4.7 (controlled side)
+Lorsqu'elle est activée, le mot de passe permanent est également autorisé lorsque la session actuelle est sur un écran de connexion ou de verrouillage. Cela s'applique aux modes d'approbation Click, Password et Both. Disponible dans le client RustDesk >=1.4.7 (côté contrôlé)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.fr.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.fr.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Si permettre la saisie de mot de passe sur l'écran de connexion quand le [mode d'approbation par clic uniquement](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) est utilisé, disponible dans le client RustDesk >=1.3.1 (côté contrôlé)
 
-Lorsqu'elle est activée, le mot de passe permanent est également autorisé lorsque la session Windows actuelle est sur un écran de connexion ou de verrouillage. RustDesk client >=1.4.7 (controlled side)
+Lorsqu'elle est activée, le mot de passe permanent est également autorisé lorsque la session actuelle est sur un écran de connexion ou de verrouillage. Cela s'applique aux modes d'approbation Click, Password et Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.it.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.it.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Se permettere input password sulla schermata di accesso quando si usa [modalità approvazione solo clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponibile nel client RustDesk >=1.3.1 (lato controllato)
 
-Quando è abilitata, la password permanente è consentita anche quando la sessione Windows corrente si trova nella schermata di accesso o di blocco. RustDesk client >=1.4.7 (controlled side)
+Quando è abilitata, la password permanente è consentita anche quando la sessione corrente si trova nella schermata di accesso o di blocco. Questo si applica alle modalità di approvazione Click, Password e Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.it.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.it.md
@@ -1307,7 +1307,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Se permettere input password sulla schermata di accesso quando si usa [modalità approvazione solo clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponibile nel client RustDesk >=1.3.1 (lato controllato)
 
-Quando è abilitata, la password permanente è consentita anche quando la sessione corrente si trova nella schermata di accesso o di blocco. Questo si applica alle modalità di approvazione Click, Password e Both. RustDesk client >=1.4.7 (controlled side)
+Quando è abilitata, la password permanente è consentita anche quando la sessione corrente si trova nella schermata di accesso o di blocco. Questo si applica alle modalità di approvazione Click, Password e Both. Disponibile nel client RustDesk >=1.4.7 (lato controllato)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ja.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ja.md
@@ -1318,7 +1318,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 [クリックのみ承認モード](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)が使用されている場合にログオン画面でのパスワード入力を許可するかどうか、RustDeskクライアント>=1.3.1（被制御側）で利用可能
 
-有効にすると、現在の Windows セッションがログオン画面またはロック画面の状態にある場合にも、固定パスワードを使用できます。 RustDesk client >=1.4.7 (controlled side)
+有効にすると、現在のセッションがログオン画面またはロック画面の状態にある場合にも、固定パスワードを使用できます。これは Click、Password、Both の承認モードに適用されます。 RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ja.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ja.md
@@ -1318,7 +1318,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 [クリックのみ承認モード](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)が使用されている場合にログオン画面でのパスワード入力を許可するかどうか、RustDeskクライアント>=1.3.1（被制御側）で利用可能
 
-有効にすると、現在のセッションがログオン画面またはロック画面の状態にある場合にも、固定パスワードを使用できます。これは Click、Password、Both の承認モードに適用されます。 RustDesk client >=1.4.7 (controlled side)
+有効にすると、現在のセッションがログオン画面またはロック画面の状態にある場合にも、固定パスワードを使用できます。これは Click、Password、Both の承認モードに適用されます。 RustDeskクライアント>=1.4.7（被制御側）で利用可能
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pl.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pl.md
@@ -1319,7 +1319,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Jeśli zezwolisz na wprowadzanie hasła na ekranie logowania podczas korzystania z trybu zatwierdzania wyłącznie kliknięciem (https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), dostępnego w kliencie RustDeska >=1.3.1 (strona kontrolowana).
 
-Po włączeniu stałe hasło jest również dozwolone, gdy bieżąca sesja Windows znajduje się na ekranie logowania lub blokady. RustDesk client >=1.4.7 (controlled side)
+Po włączeniu stałe hasło jest również dozwolone, gdy bieżąca sesja znajduje się na ekranie logowania lub blokady. Dotyczy to trybów zatwierdzania Click, Password i Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pl.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pl.md
@@ -1319,7 +1319,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Jeśli zezwolisz na wprowadzanie hasła na ekranie logowania podczas korzystania z trybu zatwierdzania wyłącznie kliknięciem (https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), dostępnego w kliencie RustDeska >=1.3.1 (strona kontrolowana).
 
-Po włączeniu stałe hasło jest również dozwolone, gdy bieżąca sesja znajduje się na ekranie logowania lub blokady. Dotyczy to trybów zatwierdzania Click, Password i Both. RustDesk client >=1.4.7 (controlled side)
+Po włączeniu stałe hasło jest również dozwolone, gdy bieżąca sesja znajduje się na ekranie logowania lub blokady. Dotyczy to trybów zatwierdzania Click, Password i Both. Dostępne w kliencie RustDesk >=1.4.7 (strona kontrolowana)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pt.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pt.md
@@ -1309,7 +1309,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Se permitir entrada de senha na tela de logon quando [modo de aprovação apenas clique](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) for usado, disponível no cliente RustDesk >=1.3.1 (lado controlado)
 
-Quando habilitado, a senha permanente também é permitida quando a sessão atual está em estado de logon ou tela de bloqueio. Isso se aplica aos modos de aprovação Click, Password e Both. RustDesk client >=1.4.7 (controlled side)
+Quando habilitado, a senha permanente também é permitida quando a sessão atual está em estado de logon ou tela de bloqueio. Isso se aplica aos modos de aprovação Click, Password e Both. Disponível no cliente RustDesk >=1.4.7 (lado controlado)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pt.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pt.md
@@ -1309,7 +1309,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Se permitir entrada de senha na tela de logon quando [modo de aprovação apenas clique](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode) for usado, disponível no cliente RustDesk >=1.3.1 (lado controlado)
 
-Quando habilitado, a senha permanente também é permitida quando a sessão atual do Windows está em estado de logon ou tela de bloqueio. RustDesk client >=1.4.7 (controlled side)
+Quando habilitado, a senha permanente também é permitida quando a sessão atual está em estado de logon ou tela de bloqueio. Isso se aplica aos modos de aprovação Click, Password e Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ro.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ro.md
@@ -1320,7 +1320,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Dacă se permite introducerea parolei pe ecranul de logare când se folosește [modul de aprobare doar prin clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponibil în clientul RustDesk >=1.3.1 (partea controlată)
 
-Când este activată, parola permanentă este permisă și atunci când sesiunea curentă este într-o stare de autentificare sau ecran blocat. Acest lucru se aplică modurilor de aprobare Click, Password și Both. RustDesk client >=1.4.7 (controlled side)
+Când este activată, parola permanentă este permisă și atunci când sesiunea curentă este într-o stare de autentificare sau ecran blocat. Acest lucru se aplică modurilor de aprobare Click, Password și Both. Disponibil în clientul RustDesk >=1.4.7 (partea controlată)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ro.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ro.md
@@ -1320,7 +1320,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 Dacă se permite introducerea parolei pe ecranul de logare când se folosește [modul de aprobare doar prin clic](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode), disponibil în clientul RustDesk >=1.3.1 (partea controlată)
 
-Când este activată, parola permanentă este permisă și atunci când sesiunea Windows curentă este într-o stare de autentificare sau ecran blocat. RustDesk client >=1.4.7 (controlled side)
+Când este activată, parola permanentă este permisă și atunci când sesiunea curentă este într-o stare de autentificare sau ecran blocat. Acest lucru se aplică modurilor de aprobare Click, Password și Both. RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
@@ -1309,7 +1309,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 在使用[仅点击批准模式](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)时是否允许在登录屏幕上输入密码，在RustDesk客户端>=1.3.1（受控端）中可用
 
-启用后，当当前 Windows 会话处于登录界面或锁屏状态时，也允许使用固定密码。 RustDesk client >=1.4.7 (controlled side)
+启用后，当当前会话处于登录界面或锁屏状态时，也允许使用固定密码。这适用于 Click、Password 和 Both 批准模式。 RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
@@ -1309,7 +1309,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 在使用[仅点击批准模式](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)时是否允许在登录屏幕上输入密码，在RustDesk客户端>=1.3.1（受控端）中可用
 
-启用后，当当前会话处于登录界面或锁屏状态时，也允许使用固定密码。这适用于 Click、Password 和 Both 批准模式。 RustDesk client >=1.4.7 (controlled side)
+启用后，当当前会话处于登录界面或锁屏状态时，也允许使用固定密码。这适用于 Click、Password 和 Both 批准模式。在RustDesk客户端>=1.4.7（受控端）中可用
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
@@ -1320,7 +1320,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 在使用[僅點擊批准模式](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)時是否允許在登入畫面上輸入密碼，在RustDesk用戶端>=1.3.1（受控端）中可用
 
-啟用後，當目前的 Windows 工作階段處於登入畫面或鎖定畫面狀態時，也允許使用固定密碼。 RustDesk client >=1.4.7 (controlled side)
+啟用後，當目前的工作階段處於登入畫面或鎖定畫面狀態時，也允許使用固定密碼。這適用於 Click、Password 和 Both 批准模式。 RustDesk client >=1.4.7 (controlled side)
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
@@ -1320,7 +1320,7 @@ https://github.com/rustdesk/rustdesk/discussions/9010
 
 在使用[僅點擊批准模式](https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#approve-mode)時是否允許在登入畫面上輸入密碼，在RustDesk用戶端>=1.3.1（受控端）中可用
 
-啟用後，當目前的工作階段處於登入畫面或鎖定畫面狀態時，也允許使用固定密碼。這適用於 Click、Password 和 Both 批准模式。 RustDesk client >=1.4.7 (controlled side)
+啟用後，當目前的工作階段處於登入畫面或鎖定畫面狀態時，也允許使用固定密碼。這適用於 Click、Password 和 Both 批准模式。在RustDesk用戶端>=1.4.7（受控端）中可用
 
 https://github.com/rustdesk/rustdesk/discussions/9269
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the allow-logon-screen-password setting across all supported languages: it now specifies that permanent passwords are allowed when the current session is at a logon or lock screen and explicitly applies to approval modes Click, Password, and Both.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->