### PR TITLE
Remove winget installation option from client-deployment

### DIFF
--- a/content/self-host/client-deployment/_index.de.md
+++ b/content/self-host/client-deployment/_index.de.md
@@ -3,7 +3,7 @@ title: Client-Bereitstellung
 weight: 400
 pre: "<b>2.4. </b>"
 description: "RustDesk-Dokumentation zu Client-Bereitstellung. Hier finden Sie Anleitungen zur Installation, Konfiguration, Bereitstellung und Fehlerbehebung."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->

--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -2,15 +2,15 @@
 title: Client Deployment
 weight: 400
 pre: "<b>2.4. </b>"
-description: "Deploy RustDesk clients at scale with PowerShell, batch, winget, or macOS bash scripts. Use these deployment examples to install RustDesk, apply config strings, and set passwords automatically."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+description: "Deploy RustDesk clients at scale with PowerShell, batch, or macOS bash scripts. Use these deployment examples to install RustDesk, apply config strings, and set passwords automatically."
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
-This guide covers large-scale RustDesk client deployment with scripts and automation tools such as PowerShell, batch, winget, and macOS bash. If you need the simplest experience and have RustDesk Server Pro, start with the custom client generator: https://twitter.com/rustdesk/status/1788905463678951787.
+This guide covers large-scale RustDesk client deployment with scripts and automation tools such as PowerShell, batch, and macOS bash. If you need the simplest experience and have RustDesk Server Pro, start with the custom client generator: https://twitter.com/rustdesk/status/1788905463678951787.
 
 ## What is the best way to deploy RustDesk clients at scale?
 
-For RustDesk Server Pro, the easiest large-scale deployment path is usually the custom client generator because it packages your server settings into the client build. For environments managed through RMM, Intune, GPO, or custom automation, PowerShell, batch, winget, and shell scripts are more flexible.
+For RustDesk Server Pro, the easiest large-scale deployment path is usually the custom client generator because it packages your server settings into the client build. For environments managed through RMM, Intune, GPO, or custom automation, PowerShell, batch, and shell scripts are more flexible.
 
 ## Which deployment method should you choose?
 
@@ -20,7 +20,6 @@ For RustDesk Server Pro, the easiest large-scale deployment path is usually the 
 | PowerShell | Windows fleet automation | Good fit for RMM, Intune, and scripted installs |
 | Batch or cmd | Basic Windows scripting | Works in simpler Windows environments without PowerShell-heavy tooling |
 | MSI | Managed Windows software deployment | Better fit when you already use MSI-based packaging workflows |
-| Winget | Modern Windows package automation | Simple install path on newer Windows systems |
 | macOS bash | Mac fleet deployment | Scriptable installation and config for macOS hosts |
 
 ## What inputs do deployment scripts need?
@@ -212,16 +211,6 @@ You can also use msi instead of `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-you can deploy via powershell with winget as well (this installs via microsofts version of apt - part of most recent windows installs)
-
-from a powershell window or via script (for example via GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.es.md
+++ b/content/self-host/client-deployment/_index.es.md
@@ -3,7 +3,7 @@ title: Despliegue de Cliente
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Documentación de RustDesk sobre Despliegue de Cliente. Consulta guías de instalación, configuración, despliegue y solución de problemas."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ También puedes usar msi en lugar de `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-puedes desplegar vía powershell con winget también (esto instala vía la versión de Microsoft de apt - parte de las instalaciones de Windows más recientes)
-
-desde una ventana de powershell o vía script (por ejemplo vía GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.fr.md
+++ b/content/self-host/client-deployment/_index.fr.md
@@ -3,7 +3,7 @@ title: Déploiement Client
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Documentation RustDesk sur Déploiement Client. Consultez les guides d'installation, de configuration, de déploiement et de dépannage."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ Vous pouvez aussi utiliser msi au lieu de `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-vous pouvez déployer via powershell avec winget également (cela s'installe via la version Microsoft d'apt - partie des installations Windows les plus récentes)
-
-depuis une fenêtre powershell ou via un script (par exemple via GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.it.md
+++ b/content/self-host/client-deployment/_index.it.md
@@ -3,7 +3,7 @@ title: Distribuzione Client
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Documentazione RustDesk su Distribuzione Client. Consulta le guide per installazione, configurazione, distribuzione e risoluzione dei problemi."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ Puoi anche usare msi invece di `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-puoi distribuire tramite powershell con winget anche (questo installa tramite la versione Microsoft di apt - parte delle installazioni Windows più recenti)
-
-da una finestra powershell o tramite script (ad esempio tramite GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.ja.md
+++ b/content/self-host/client-deployment/_index.ja.md
@@ -3,7 +3,7 @@ title: クライアントデプロイメント
 weight: 400
 pre: "<b>2.4. </b>"
 description: "RustDesk のクライアントデプロイメントに関するドキュメントです。インストール、設定、展開、トラブルシューティングのガイドを参照できます。"
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ echo ...............................................
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-wingetを使ってpowershell経由でデプロイすることもできます（これは最近のWindowsインストールの一部であるMicrosoft版apt経由でインストールします）
-
-powershellウィンドウから、またはスクリプト経由で（例えばGPO経由）
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.pl.md
+++ b/content/self-host/client-deployment/_index.pl.md
@@ -3,7 +3,7 @@ title: Wdrażanie klientów
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Dokumentacja RustDesk dotycząca Wdrażanie klientów. Zawiera instrukcje instalacji, konfiguracji, wdrażania i rozwiązywania problemów."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ Można również użyć msi zamiast `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/pl/client/windows/msi/
 
-
-## Winget
-
-można również wdrożyć za pomocą powershella z winget (instaluje się to za pomocą wersji apt firmy Microsoft — części najnowszych instalacji systemu Windows)
-
-z okna powershella lub za pomocą skryptu (na przykład za pomocą GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.pt.md
+++ b/content/self-host/client-deployment/_index.pt.md
@@ -3,7 +3,7 @@ title: Implantação do Cliente
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Documentação do RustDesk sobre Implantação do Cliente. Consulte guias de instalação, configuração, implantação e solução de problemas."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ Você também pode usar msi em vez de `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-você pode implantar via powershell com winget também (isso instala via a versão da Microsoft do apt - parte das instalações mais recentes do Windows)
-
-de uma janela do powershell ou via script (por exemplo via GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.ro.md
+++ b/content/self-host/client-deployment/_index.ro.md
@@ -3,7 +3,7 @@ title: Deployare client
 weight: 400
 pre: "<b>2.4. </b>"
 description: "Documentație RustDesk pentru Deployare client. Găsiți ghiduri de instalare, configurare, implementare și depanare."
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ Puteți folosi MSI în loc de `rustdesk.exe --silent-install`.
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-puteți implementa prin powershell cu winget de asemenea (instalează via managerul Microsoft - parte din cele mai recente instalări Windows)
-
-dintr-o fereastră powershell sau via script (de exemplu prin GPO)
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.zh-cn.md
+++ b/content/self-host/client-deployment/_index.zh-cn.md
@@ -3,7 +3,7 @@ title: 客户端部署
 weight: 400
 pre: "<b>2.4. </b>"
 description: "RustDesk 的客户端部署文档，提供安装、配置、部署和故障排查指南。"
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ echo ...............................................
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-您也可以通过 powershell 使用 winget 进行部署（这通过微软版本的 apt 安装 - 大多数最新 Windows 安装的一部分）
-
-从 powershell 窗口或通过脚本（例如通过 GPO）
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 

--- a/content/self-host/client-deployment/_index.zh-tw.md
+++ b/content/self-host/client-deployment/_index.zh-tw.md
@@ -3,7 +3,7 @@ title: 客戶端部署
 weight: 400
 pre: "<b>2.4. </b>"
 description: "RustDesk 的客戶端部署文檔，提供安裝、設定、部署與疑難排解指南。"
-keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk winget", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
+keywords: ["rustdesk client deployment", "rustdesk powershell deploy", "rustdesk mass deployment", "rustdesk intune", "rustdesk rmm", "rustdesk silent deployment"]
 ---
 
 <!-- GEO-LOCALIZED-INTRO:START -->
@@ -204,16 +204,6 @@ echo ...............................................
 
 https://rustdesk.com/docs/en/client/windows/msi/
 
-
-## Winget
-
-您也可以透過帶有 winget 的 powershell 進行部署（這會透過 Microsoft 版本的 apt 進行安裝 - 大多數最新 Windows 安裝的一部分）
-
-從 powershell 視窗或透過腳本（例如透過 GPO）
-
-```
-winget install --id=RustDesk.RustDesk  -e
-```
 
 ## macOS Bash
 


### PR DESCRIPTION
RustDesk is no longer available via winget, cf. https://x.com/rustdesk/status/2036632270837297444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Windows Winget deployment guidance from client deployment documentation across all supported language versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/doc.rustdesk.com/pull/607)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->