### PR TITLE
update advanced options

### DIFF
--- a/content/self-host/client-configuration/advanced-settings/_index.de.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.de.md
@@ -1542,3 +1542,13 @@ Verfügbar seit RustDesk 1.4.5
 | Werte | Standard | Beispiel |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Ermöglicht die Konfiguration über Befehlszeileneinstellungen, wenn `Einstellungen deaktivieren` im benutzerdefinierten Client aktiviert ist. Wenn auf Y gesetzt, sind nur die UI-Einstellungen deaktiviert, aber Befehlszeileneinstellungen können weiterhin zur Konfiguration des Clients verwendet werden.
+
+Verfügbar seit RustDesk 1.4.7
+
+| Werte | Standard | Beispiel |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.en.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.en.md
@@ -1564,3 +1564,13 @@ Available since RustDesk 1.4.5
 | Values | Default | Example |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Allow configuration via command-line settings when `Disable settings` is enabled in custom client. When set to Y, only the UI settings are disabled, but command-line settings can still be used to configure the client.
+
+Available since RustDesk 1.4.7
+
+| Values | Default | Example |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.es.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.es.md
@@ -1542,3 +1542,13 @@ Disponible desde RustDesk 1.4.5
 | Valores | Predeterminado | Ejemplo |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Permite la configuración a través de ajustes de línea de comandos cuando `Deshabilitar configuración` está habilitado en el cliente personalizado. Cuando se establece en Y, solo se deshabilitan los ajustes de la interfaz de usuario, pero los ajustes de línea de comandos aún se pueden usar para configurar el cliente.
+
+Disponible desde RustDesk 1.4.7
+
+| Valores | Predeterminado | Ejemplo |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.fr.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.fr.md
@@ -1542,3 +1542,13 @@ Disponible depuis RustDesk 1.4.5
 | Valeurs | Par défaut | Exemple |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Permet la configuration via les paramètres de ligne de commande lorsque `Désactiver les paramètres` est activé dans le client personnalisé. Lorsque défini sur Y, seuls les paramètres de l'interface utilisateur sont désactivés, mais les paramètres de ligne de commande peuvent toujours être utilisés pour configurer le client.
+
+Disponible depuis RustDesk 1.4.7
+
+| Valeurs | Par défaut | Exemple |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.it.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.it.md
@@ -1542,3 +1542,13 @@ Disponibile da RustDesk 1.4.5
 | Valori | Predefinito | Esempio |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Consente la configurazione tramite impostazioni da riga di comando quando `Disabilita impostazioni` è abilitato nel client personalizzato. Quando impostato su Y, solo le impostazioni dell'interfaccia utente sono disabilitate, ma le impostazioni da riga di comando possono ancora essere utilizzate per configurare il client.
+
+Disponibile da RustDesk 1.4.7
+
+| Valori | Predefinito | Esempio |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.ja.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ja.md
@@ -1552,3 +1552,13 @@ RustDesk 1.4.5 以降で利用可能
 | 値 | デフォルト | 例 |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+カスタムクライアントで`設定を無効にする`が有効になっている場合に、コマンドライン設定による構成を許可します。Yに設定すると、UI設定のみが無効になりますが、コマンドライン設定を使用してクライアントを構成することができます。
+
+RustDesk 1.4.7 以降で利用可能
+
+| 値 | デフォルト | 例 |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.pl.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pl.md
@@ -1554,3 +1554,13 @@ Dostępne od RustDesk 1.4.5
 | Wartości | Domyślnie | Przykład |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Umożliwia konfigurację za pomocą ustawień wiersza poleceń, gdy `Wyłącz ustawienia` jest włączone w niestandardowym kliencie. Po ustawieniu na Y, tylko ustawienia interfejsu użytkownika są wyłączone, ale ustawienia wiersza poleceń nadal mogą być używane do konfiguracji klienta.
+
+Dostępne od RustDesk 1.4.7
+
+| Wartości | Domyślnie | Przykład |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.pt.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pt.md
@@ -1544,3 +1544,13 @@ Disponível desde RustDesk 1.4.5
 | Valores | Padrão | Exemplo |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Permite a configuração através de configurações de linha de comando quando `Desabilitar configurações` está habilitado no cliente personalizado. Quando definido como Y, apenas as configurações da interface do usuário são desabilitadas, mas as configurações de linha de comando ainda podem ser usadas para configurar o cliente.
+
+Disponível desde RustDesk 1.4.7
+
+| Valores | Padrão | Exemplo |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.ro.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ro.md
@@ -1555,3 +1555,13 @@ Disponibil din RustDesk 1.4.5
 | Valori | Implicit | Exemplu |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+Permite configurarea prin setări de linie de comandă când `Dezactivare setări` este activat în clientul personalizat. Când este setat pe Y, doar setările interfeței utilizator sunt dezactivate, dar setările de linie de comandă pot fi în continuare utilizate pentru a configura clientul.
+
+Disponibil din RustDesk 1.4.7
+
+| Valori | Implicit | Exemplu |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
@@ -1545,3 +1545,13 @@ https://github.com/rustdesk/rustdesk/pull/12911
 | 值 | 默认值 | 示例 |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+当自定义客户端中启用了"禁用设置"时，允许通过命令行参数进行配置。设置为 Y 后，仅禁用 UI 设置界面，但仍可使用命令行参数配置客户端。
+
+自 RustDesk 1.4.7 版本起可用
+
+| 值 | 默认值 | 示例 |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
@@ -1555,3 +1555,13 @@ https://github.com/rustdesk/rustdesk/pull/12911
 | 值 | 預設值 | 範例 |
 | :------: | :------: | :------: |
 | Y, N | N | `disable-unlock-pin=Y` |
+
+### allow-command-line-settings-when-settings-disabled
+
+當自訂客戶端中啟用了「禁用設定」時，允許透過命令列參數進行配置。設定為 Y 後，僅禁用 UI 設定介面，但仍可使用命令列參數配置客戶端。
+
+自 RustDesk 1.4.7 起可用
+
+| 值 | 預設值 | 範例 |
+| :------: | :------: | :------: |
+| Y, N | N | `allow-command-line-settings-when-settings-disabled=Y` |


### PR DESCRIPTION
Add option `allow-command-line-settings-when-settings-disabled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation across all supported languages for a new advanced setting that enables command-line configuration of clients even when UI settings are disabled in custom clients (available since RustDesk 1.4.7).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/doc.rustdesk.com/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->