### PR TITLE
Fix file path in rustdesk-hbbr.service removal command

### DIFF
--- a/content/self-host/rustdesk-server-pro/faq/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.en.md
@@ -192,7 +192,7 @@ sudo systemctl stop rustdesk-hbbr.service
 sudo systemctl disable rustdesk-hbbr.service
 sudo systemctl daemon-reload
 sudo rm /etc/systemd/system/rustdesk-hbbs.service
-sudo rm etc/systemd/system/rustdesk-hbbr.service
+sudo rm /etc/systemd/system/rustdesk-hbbr.service
 sudo rm /usr/bin/hbbs
 sudo rm /usr/bin/hbbr
 sudo rm -rf /var/lib/rustdesk-server/


### PR DESCRIPTION
added missing / to uninstall path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the uninstall instructions to use the proper full path when removing the system service file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->