### PR TITLE
Linux deployment scripts piped to a file named "null" instead of /dev/null

### DIFF
--- a/content/self-host/client-deployment/_index.de.md
+++ b/content/self-host/client-deployment/_index.de.md
@@ -342,10 +342,10 @@ fi
 echo "Installieren von RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.3/rustdesk-1.2.3-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.3-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.3-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.3/rustdesk-1.2.3-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.3-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.3-0.x86_64.rpm -y > /dev/null
 else
     echo "Nicht unterstütztes OS"
     # Hier könnten Sie den Benutzer um Erlaubnis bitten, die Installation trotzdem zu versuchen

--- a/content/self-host/client-deployment/_index.en.md
+++ b/content/self-host/client-deployment/_index.en.md
@@ -354,10 +354,10 @@ fi
 echo "Installing RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "Unsupported OS"
     # here you could ask the user for permission to try and install anyway

--- a/content/self-host/client-deployment/_index.es.md
+++ b/content/self-host/client-deployment/_index.es.md
@@ -347,10 +347,10 @@ fi
 echo "Instalando RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "OS no soportado"
     # aquí podrías preguntar al usuario por permiso para intentar instalar de todos modos

--- a/content/self-host/client-deployment/_index.fr.md
+++ b/content/self-host/client-deployment/_index.fr.md
@@ -347,10 +347,10 @@ fi
 echo "Installation de RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "OS non supporté"
     # ici vous pourriez demander à l'utilisateur la permission d'essayer d'installer quand même

--- a/content/self-host/client-deployment/_index.it.md
+++ b/content/self-host/client-deployment/_index.it.md
@@ -347,10 +347,10 @@ fi
 echo "Installazione di RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "OS non supportato"
     # qui potresti chiedere all'utente il permesso di provare a installare comunque

--- a/content/self-host/client-deployment/_index.ja.md
+++ b/content/self-host/client-deployment/_index.ja.md
@@ -347,10 +347,10 @@ fi
 echo "RustDeskをインストール中"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "サポートされていないOS"
     # ここでユーザーにとにかくインストールを試す許可を求めることができます

--- a/content/self-host/client-deployment/_index.pl.md
+++ b/content/self-host/client-deployment/_index.pl.md
@@ -347,10 +347,10 @@ fi
 echo "Instalacja RustDeska"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "Niewspierany system operacyjny"
     # tutaj można poprosić użytkownika o zgodę na próbę instalacji mimo wszystko

--- a/content/self-host/client-deployment/_index.pt.md
+++ b/content/self-host/client-deployment/_index.pt.md
@@ -347,10 +347,10 @@ fi
 echo "Instalando RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "SO não suportado"
     # aqui você pode perguntar ao usuário permissão para tentar instalar mesmo assim

--- a/content/self-host/client-deployment/_index.ro.md
+++ b/content/self-host/client-deployment/_index.ro.md
@@ -347,10 +347,10 @@ fi
 echo "Installing RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
 	wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-	apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+	apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
 	wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-	yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+	yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
 	echo "Unsupported OS"
 	# here you could ask the user for permission to try and install anyway

--- a/content/self-host/client-deployment/_index.zh-cn.md
+++ b/content/self-host/client-deployment/_index.zh-cn.md
@@ -347,10 +347,10 @@ fi
 echo "正在安装 RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "不支持的操作系统"
     # 这里您可以询问用户是否允许尝试安装

--- a/content/self-host/client-deployment/_index.zh-tw.md
+++ b/content/self-host/client-deployment/_index.zh-tw.md
@@ -347,10 +347,10 @@ fi
 echo "正在安裝 RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ] || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-x86_64.deb
-    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null
+    apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ] || [ "${UPSTREAM_ID}" = "rhel" ] || [ "$OS" = "Almalinux" ] || [ "$OS" = "Rocky*" ] ; then
     wget https://github.com/rustdesk/rustdesk/releases/download/1.2.6/rustdesk-1.2.6-0.x86_64.rpm
-    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null
+    yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null
 else
     echo "不支援的作業系統"
     # 在這裡您可以詢問使用者是否允許嘗試安裝


### PR DESCRIPTION
The `Install RustDesk` part of the [Linux deployment scripts](https://rustdesk.com/docs/en/self-host/client-deployment/#linux) for self-hosted rustdesk piped to a file named `null` instead of the null-device `/dev/null`. I have just searched all entries with:

`apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > null`
and
`yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > null`

and replaced, respectively, with

`apt-get install -fy ./rustdesk-1.2.6-x86_64.deb > /dev/null`
and
`yum localinstall ./rustdesk-1.2.6-0.x86_64.rpm -y > /dev/null`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Linux install output handling so package installation messages are properly suppressed during client deployment.
  * Applied the fix across both Debian/Ubuntu and RPM-based installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->