### PR TITLE
fix(faq): update stale #install anchor across all locales

### DIFF
--- a/content/self-host/rustdesk-server-pro/faq/_index.de.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.de.md
@@ -25,7 +25,7 @@ Nutzen Sie diese FAQ, wenn Sie schnelle Antworten zu Installation, Upgrades, Liz
 1. Holen Sie sich Ihre Lizenz von [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html). Auf der Seite [Lizenz](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/license/) finden Sie weitere Informationen.
 2. Richten Sie einen VPS, einen physischen Server oder eine Linux-VM ein.
 3. Wenn Sie DNS und SSL verwenden möchten, legen Sie einen DNS-Namen an, z. B. `trustdesk.ihredomain.de`.
-4. Gehen Sie zu [dieser Seite](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/installscript/#installation).
+4. Gehen Sie zu [dieser Seite](https://rustdesk.com/docs/de/self-host/rustdesk-server-pro/installscript/#verfahren-2-installsh).
 5. Kopieren Sie den Befehl und fügen Sie ihn in Ihr Linux-Terminal ein.
 6. Folgen Sie den Aufforderungen, die Sie durch die Installation führen.
 7. Sobald die Installation abgeschlossen ist, gehen Sie zu `https://rustdesk.ihredomain.com` oder `http://ihreipadresse:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.en.md
@@ -25,7 +25,7 @@ This FAQ covers the most common RustDesk Server Pro tasks: installation, convers
 1. Get your license from [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), check [license](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) page for more details.
 2. Spin up a VPS, bare metal or Linux VM.
 3. If you want to use DNS and SSL create a DNS name i.e. `rustdesk.yourdomain.com`.
-4. [This page](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. [This page](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#method-2-installsh).
 5. Copy and paste the command into your Linux terminal.
 6. Follow the prompts as they guide you through the install.
 7. Once the install is complete `https://rustdesk.yourdomain.com` or `http://youripaddress:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.es.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.es.md
@@ -25,7 +25,7 @@ Use este FAQ cuando necesite respuestas rápidas sobre instalación, actualizaci
 1. Obtén tu licencia desde [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), consulta la página de [licencia](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) para más detalles.
 2. Inicia un VPS, metal desnudo o VM Linux.
 3. Si quieres usar DNS y SSL, crea un nombre DNS como `rustdesk.yourdomain.com`.
-4. [Esta página](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. [Esta página](https://rustdesk.com/docs/es/self-host/rustdesk-server-pro/installscript/#método-2-installsh).
 5. Copia y pega el comando en tu terminal Linux.
 6. Sigue las indicaciones que te guían a través de la instalación.
 7. Una vez completada la instalación, ve a `https://rustdesk.yourdomain.com` o `http://youripaddress:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.fr.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.fr.md
@@ -25,7 +25,7 @@ Utilisez cette FAQ si vous avez besoin de réponses rapides sur l’installation
 1. Obtenez votre licence depuis [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), consultez la page [licence](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) pour plus de détails.
 2. Lancez un VPS, un serveur dédié ou une VM Linux.
 3. Si vous voulez utiliser DNS et SSL, créez un nom DNS par exemple `rustdesk.yourdomain.com`.
-4. [Cette page](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. [Cette page](https://rustdesk.com/docs/fr/self-host/rustdesk-server-pro/installscript/#méthode-2--installsh).
 5. Copiez et collez la commande dans votre terminal Linux.
 6. Suivez les invites qui vous guident à travers l'installation.
 7. Une fois l'installation terminée, allez sur `https://rustdesk.yourdomain.com` ou `http://youripaddress:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.it.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.it.md
@@ -25,7 +25,7 @@ Usa questa FAQ quando ti servono risposte rapide su installazione, aggiornamenti
 1. Ottieni la tua licenza da [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), controlla la pagina [licenza](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) per maggiori dettagli.
 2. Avvia un VPS, bare metal o VM Linux.
 3. Se vuoi usare DNS e SSL, crea un nome DNS come `rustdesk.yourdomain.com`.
-4. [Questa pagina](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. [Questa pagina](https://rustdesk.com/docs/it/self-host/rustdesk-server-pro/installscript/#metodo-2-installsh).
 5. Copia e incolla il comando nel tuo terminale Linux.
 6. Segui i prompt che ti guidano attraverso l'installazione.
 7. Una volta completata l'installazione vai su `https://rustdesk.yourdomain.com` o `http://youripaddress:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.ja.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.ja.md
@@ -25,7 +25,7 @@ weight: 600
 1. [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html)からライセンスを取得し、詳細については[ライセンス](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/)ページを確認してください。
 2. VPS、ベアメタル、またはLinux VMを起動します。
 3. DNSとSSLを使用したい場合は、`rustdesk.yourdomain.com`のようなDNS名を作成します。
-4. [このページ](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install)。
+4. [このページ](https://rustdesk.com/docs/ja/self-host/rustdesk-server-pro/installscript/#方法2-installsh)。
 5. Linuxターミナルにコマンドをコピー＆ペーストします。
 6. インストールを案内するプロンプトに従います。
 7. インストールが完了したら`https://rustdesk.yourdomain.com`または`http://youripaddress:21114`にアクセスします。

--- a/content/self-host/rustdesk-server-pro/faq/_index.ko.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.ko.md
@@ -25,7 +25,7 @@ weight: 600
 1. [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html)로부터 라이선스를 받고, 자세한 내용은 [license](/docs/ko/self-host/rustdesk-server-pro/license/) 페이지를 확인하세요.
 2. VPS, 베어 메탈 또는 Linux VM을 생성하세요.
 3. DNS와 SSL을 사용하려면 DNS 이름, 예를 들어 `rustdesk.yourdomain.com`를 생성하세요.
-4. [This page](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install)를 실행하세요.
+4. [This page](https://rustdesk.com/docs/ko/self-host/rustdesk-server-pro/installscript/#방법-2-installsh)를 실행하세요.
 5. 명령어를 복사하여 Linux 터미널에 붙여넣으세요.
 6. 안내에 따라 설치를 진행하세요.
 7. 설치가 완료되면 `https://rustdesk.yourdomain.com` 또는 `http://youripaddress:21114`를 실행하세요.

--- a/content/self-host/rustdesk-server-pro/faq/_index.pl.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.pl.md
@@ -25,7 +25,7 @@ Korzystaj z tego FAQ, gdy potrzebujesz szybkich odpowiedzi dotyczących instalac
 1. Uzyskaj licencję ze strony [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html). Więcej szczegółów znajdziesz na stronie [licencji](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/).
 2. Przygotuj VPS, serwer fizyczny lub maszynę wirtualną z systemem Linux.
 3. Jeśli chcesz użyć DNS i SSL, utwórz nazwę DNS, np. `rustdesk.twojadomena.com`.
-4. Przejdź na [tę stronę](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. Przejdź na [tę stronę](https://rustdesk.com/docs/pl/self-host/rustdesk-server-pro/installscript/#metoda-2-installsh).
 5. Skopiuj i wklej polecenie do terminala Linux.
 6. Postępuj zgodnie z instrukcjami wyświetlanymi podczas instalacji.
 7. Po zakończeniu instalacji otwórz `https://rustdesk.twojadomena.com` lub `http://twoj.adres.ip:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.pt.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.pt.md
@@ -25,7 +25,7 @@ Use este FAQ quando precisar de respostas rápidas sobre instalação, upgrades,
 1. Obtenha sua licença em [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html), consulte a página de [licença](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) para mais detalhes.
 2. Inicie um VPS, bare metal ou VM Linux.
 3. Se você quiser usar DNS e SSL, crie um nome DNS como `rustdesk.yourdomain.com`.
-4. [Esta página](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install).
+4. [Esta página](https://rustdesk.com/docs/pt/self-host/rustdesk-server-pro/installscript/#método-2-installsh).
 5. Copie e cole o comando em seu terminal Linux.
 6. Siga as instruções que o guiam pela instalação.
 7. Após a instalação ser concluída, vá para `https://rustdesk.yourdomain.com` ou `http://youripaddress:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.ro.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.ro.md
@@ -25,7 +25,7 @@ Folosește acest FAQ atunci când ai nevoie de răspunsuri rapide despre instala
 1. Obține o licență de la https://rustdesk.com/pricing.html — vezi pagina de [license](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/) pentru detalii.
 2. Pornește un VPS, un server fizic sau o mașină virtuală Linux.
 3. Dacă vrei să folosești DNS și SSL, creează un nume DNS, ex. `rustdesk.domeniultau.com`.
-4. Urmează instrucțiunile de pe această pagină: https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install.
+4. Urmează instrucțiunile de pe această pagină: https://rustdesk.com/docs/ro/self-host/rustdesk-server-pro/installscript/#metoda-2-installsh.
 5. Copiază și lipește comanda în terminalul Linux.
 6. Urmează pașii interactivi din script.
 7. După instalare poți accesa `https://rustdesk.domeniultau.com` sau `http://adresa-ip:21114`.

--- a/content/self-host/rustdesk-server-pro/faq/_index.zh-cn.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.zh-cn.md
@@ -25,7 +25,7 @@ weight: 600
 1. 从 [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html) 获取许可证，查看 [license](/docs/zh-cn/self-host/rustdesk-server-pro/license) 页面了解更多详细信息。
 2. 启动 VPS、裸机或 Linux VM。
 3. 如果您想使用 DNS 和 SSL，请创建一个 DNS 名称，即`rustdesk.yourdomain.com`。
-4. 转到[此页面](https://rustdesk.com/docs/zh-cn/self-host/rustdesk-server-pro/installscript/#install)。
+4. 转到[此页面](https://rustdesk.com/docs/zh-cn/self-host/rustdesk-server-pro/installscript/#方法-2installsh)。
 5. 将命令复制并粘贴到 Linux 终端中。
 6. 按照提示完成安装。
 7. 安装完成后，转到`https://rustdesk.yourdomain.com`或`http://youripaddress:21114`。

--- a/content/self-host/rustdesk-server-pro/faq/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-pro/faq/_index.zh-tw.md
@@ -25,7 +25,7 @@ weight: 600
 1. 從 [https://rustdesk.com/pricing.html](https://rustdesk.com/pricing.html) 獲取您的許可證，請查看[許可證](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/license/)頁面了解更多詳情。
 2. 啟動 VPS、裸機或 Linux VM。
 3. 如果您想使用 DNS 和 SSL，請創建 DNS 名稱，例如 `rustdesk.yourdomain.com`。
-4. [此頁面](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/installscript/#install)。
+4. [此頁面](https://rustdesk.com/docs/zh-tw/self-host/rustdesk-server-pro/installscript/#方法-2installsh)。
 5. 複製並粘貼命令到您的 Linux 終端。
 6. 按照提示指導您完成安裝。
 7. 安裝完成後訪問 `https://rustdesk.yourdomain.com` 或 `http://youripaddress:21114`。


### PR DESCRIPTION
While translating the docs into Korean, I noticed the `#install` anchor on line 28 of the Server Pro FAQ no longer resolves.

The install-script section had an `### Install` heading (3bc06d1), which was later renamed to `## Method 2: install.sh` (063de19). The FAQ still points at the old `#install` anchor, so it now resolves to nothing.

This updates line 28 to the correct anchor across all 12 locales, using each locale's actual slug and localizing the path.

Split into two commits: the English source fix, then the translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Simple Install Script” FAQ across multiple languages with corrected links to the relevant installation instructions.
  * Users are now taken directly to the appropriate “Method 2” section in each localized guide, improving navigation and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->