### PR TITLE
docs: add recording advanced settings

### DIFF
--- a/content/self-host/client-configuration/advanced-settings/_index.de.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.de.md
@@ -438,9 +438,19 @@ Ausgehende Sitzungen automatisch aufzeichnen.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Blendet die Aufzeichnungsschaltfläche in Remotesitzungen auf der steuernden Seite aus. Dadurch wird die Aufzeichnung nicht deaktiviert. Wenn die automatische Aufzeichnung ausgehender Sitzungen aktiviert ist, werden Sitzungen weiterhin aufgezeichnet, Benutzer können die Aufzeichnung jedoch nicht über die Sitzungssymbolleiste beenden.
+
+| Installation erforderlich | Werte | Standard | Beispiel |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 Das Verzeichnis zum Speichern aufgezeichneter Videos.
+
+Für Aufzeichnungen, die der installierte Windows-Dienst auf der gesteuerten Seite erstellt, verwenden Sie [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Ort**:
 
@@ -455,6 +465,14 @@ Standardwerte:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Hinweis**: Ersetzen Sie **app_name** durch den aktuellen App-Namen.
+
+### windows-service-video-save-directory
+
+Das Verzeichnis, in dem ein installierter Windows-Client Aufzeichnungen speichert, wenn er als Dienst ausgeführt wird. Der Pfad muss absolut sein. Ein leerer oder relativer Pfad wird ignoriert und RustDesk verwendet stattdessen das Standardverzeichnis.
+
+| Installation erforderlich | Werte | Standard | Beispiel |
+| :------: | :------: | :------: | :------: |
+| Y | Absoluter Windows-Pfad | `<Systemlaufwerk>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.en.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.en.md
@@ -448,9 +448,19 @@ Automatically record outgoing sessions.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Hide the recording button in remote sessions on the controlling side. This does not disable recording. If automatic outgoing recording is enabled, sessions are still recorded, but users cannot stop the recording from the session toolbar.
+
+| Install required | Values | Default | Example |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 The directory to save recorded videos.
+
+For controlled-side recordings made by the installed Windows service, use [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Location**:
 
@@ -465,6 +475,14 @@ Default values:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Note**: Replace **app_name** means current app name.
+
+### windows-service-video-save-directory
+
+The directory where an installed Windows client saves recordings when running as a service. The path must be absolute. An empty or relative path is ignored, and RustDesk uses the default directory instead.
+
+| Install required | Values | Default | Example |
+| :------: | :------: | :------: | :------: |
+| Y | Absolute Windows path | `<system drive>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.es.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.es.md
@@ -438,9 +438,19 @@ Graba automáticamente sesiones salientes.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Oculta el botón de grabación en las sesiones remotas del lado controlador. Esto no deshabilita la grabación. Si la grabación automática de sesiones salientes está habilitada, las sesiones se siguen grabando, pero los usuarios no pueden detener la grabación desde la barra de herramientas de la sesión.
+
+| Instalación requerida | Valores | Predeterminado | Ejemplo |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 El directorio para guardar videos grabados.
+
+Para las grabaciones que realiza el servicio de Windows instalado en el lado controlado, usa [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Ubicación**:
 
@@ -455,6 +465,14 @@ Valores predeterminados:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Nota**: Reemplaza **app_name** con el nombre actual de la aplicación.
+
+### windows-service-video-save-directory
+
+El directorio donde un cliente de Windows instalado guarda las grabaciones cuando se ejecuta como servicio. La ruta debe ser absoluta. Las rutas vacías o relativas se ignoran y RustDesk usa el directorio predeterminado en su lugar.
+
+| Instalación requerida | Valores | Predeterminado | Ejemplo |
+| :------: | :------: | :------: | :------: |
+| Y | Ruta absoluta de Windows | `<unidad del sistema>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.fr.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.fr.md
@@ -438,9 +438,19 @@ Enregistre automatiquement les sessions sortantes.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Masque le bouton d'enregistrement dans les sessions à distance du côté contrôleur. Cela ne désactive pas l'enregistrement. Si l'enregistrement automatique des sessions sortantes est activé, les sessions sont toujours enregistrées, mais les utilisateurs ne peuvent pas arrêter l'enregistrement depuis la barre d'outils de la session.
+
+| Installation requise | Valeurs | Défaut | Exemple |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 Le répertoire pour sauvegarder les vidéos enregistrées.
+
+Pour les enregistrements effectués du côté contrôlé par le service Windows installé, utilisez [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Emplacement** :
 
@@ -455,6 +465,14 @@ Valeurs par défaut :
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Note** : Remplacez **app_name** par le nom actuel de l'application.
+
+### windows-service-video-save-directory
+
+Le répertoire dans lequel un client Windows installé stocke les enregistrements lorsqu'il s'exécute en tant que service. Le chemin doit être absolu. Un chemin vide ou relatif est ignoré et RustDesk utilise alors le répertoire par défaut.
+
+| Installation requise | Valeurs | Défaut | Exemple |
+| :------: | :------: | :------: | :------: |
+| Y | Chemin Windows absolu | `<lecteur système>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.it.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.it.md
@@ -438,9 +438,19 @@ Registra automaticamente le sessioni in uscita.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Nasconde il pulsante di registrazione nelle sessioni remote sul lato di controllo. Ciò non disabilita la registrazione. Se la registrazione automatica delle sessioni in uscita è abilitata, le sessioni vengono comunque registrate, ma gli utenti non possono interrompere la registrazione dalla barra degli strumenti della sessione.
+
+| Installazione richiesta | Valori | Predefinito | Esempio |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 La directory per salvare i video registrati.
+
+Per le registrazioni effettuate sul lato controllato dal servizio Windows installato, usa [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Posizione**:
 
@@ -455,6 +465,14 @@ Valori predefiniti:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Nota**: Sostituisci **app_name** con il nome dell'app corrente.
+
+### windows-service-video-save-directory
+
+La directory in cui un client Windows installato salva le registrazioni quando viene eseguito come servizio. Il percorso deve essere assoluto. Un percorso vuoto o relativo viene ignorato e RustDesk utilizza invece la directory predefinita.
+
+| Installazione richiesta | Valori | Predefinito | Esempio |
+| :------: | :------: | :------: | :------: |
+| Y | Percorso Windows assoluto | `<unità di sistema>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ja.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ja.md
@@ -438,9 +438,19 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+制御側のリモートセッションで録画ボタンを非表示にします。録画自体は無効になりません。発信セッションの自動録画が有効な場合、セッションは引き続き録画されますが、ユーザーはセッションツールバーから録画を停止できません。
+
+| インストール必要 | 値 | デフォルト | 例 |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 録画されたビデオを保存するディレクトリ。
+
+インストール済みのWindowsサービスによって被制御側で作成される録画には、[`windows-service-video-save-directory`](#windows-service-video-save-directory)を使用してください。
 
 **場所**：
 
@@ -455,6 +465,14 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **注意**：**app_name**を現在のアプリ名に置き換えてください。
+
+### windows-service-video-save-directory
+
+インストール済みのWindowsクライアントがサービスとして実行されているときに録画を保存するディレクトリ。パスは絶対パスでなければなりません。空または相対パスは無視され、RustDeskは代わりにデフォルトのディレクトリを使用します。
+
+| インストール必要 | 値 | デフォルト | 例 |
+| :------: | :------: | :------: | :------: |
+| Y | Windowsの絶対パス | `<システムドライブ>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ko.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ko.md
@@ -447,9 +447,19 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+제어 측의 원격 세션에서 녹화 버튼을 숨깁니다. 이 설정은 녹화를 비활성화하지 않습니다. 발신 세션 자동 녹화가 활성화되어 있으면 세션은 계속 녹화되지만, 사용자는 세션 도구 모음에서 녹화를 중지할 수 없습니다.
+
+| 설치 필요 | 값 | 기본값 | 예시 |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### 비디오 저장 디렉터리
 
 녹화된 동영상을 저장할 디렉터리입니다.
+
+설치된 Windows 서비스가 제어 대상 측에서 생성하는 녹화에는 [`windows-service-video-save-directory`](#windows-service-video-save-directory)를 사용하십시오.
 
 **위치**:
 
@@ -464,6 +474,14 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 4. **Android** /Storage/emulated/0/**앱_이름**/ScreenRecord
 
 **노트**: **앱_이름**을 현재 앱 이름으로 대체하십시오.
+
+### windows-service-video-save-directory
+
+설치된 Windows 클라이언트가 서비스로 실행될 때 녹화 파일을 저장하는 디렉터리입니다. 경로는 절대 경로여야 합니다. 비어 있거나 상대 경로인 경우 무시되며 RustDesk는 기본 디렉터리를 대신 사용합니다.
+
+| 설치 필요 | 값 | 기본값 | 예시 |
+| :------: | :------: | :------: | :------: |
+| Y | Windows 절대 경로 | `<시스템 드라이브>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### 자동 업데이트 허용
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pl.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pl.md
@@ -439,9 +439,19 @@ Automatycznie nagrywaj sesje wychodzące.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Ukrywa przycisk nagrywania w sesjach zdalnych po stronie sterującej. Nie wyłącza to nagrywania. Jeśli automatyczne nagrywanie sesji wychodzących jest włączone, sesje nadal są nagrywane, ale użytkownicy nie mogą zatrzymać nagrywania z paska narzędzi sesji.
+
+| Wymagana instalacja | Wartości | Domyślne | Przykład |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 Katalog, w którym zapisywane są nagrane filmy.
+
+W przypadku nagrań wykonywanych po stronie sterowanej przez zainstalowaną usługę Windows użyj [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Lokalizacja**:
 
@@ -456,6 +466,14 @@ Domyślne wartości:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Notka**: **app_name** oznacza aktualną nazwę aplikacji.
+
+### windows-service-video-save-directory
+
+Katalog, w którym zainstalowany klient Windows zapisuje nagrania podczas działania jako usługa. Ścieżka musi być bezwzględna. Pusta lub względna ścieżka jest ignorowana, a RustDesk używa zamiast niej katalogu domyślnego.
+
+| Wymagana instalacja | Wartości | Domyślne | Przykład |
+| :------: | :------: | :------: | :------: |
+| Y | Bezwzględna ścieżka Windows | `<dysk systemowy>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.pt.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.pt.md
@@ -438,9 +438,19 @@ Grava automaticamente sessões de saída.
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Oculta o botão de gravação nas sessões remotas no lado controlador. Isso não desativa a gravação. Se a gravação automática de sessões de saída estiver ativada, as sessões continuarão sendo gravadas, mas os usuários não poderão interromper a gravação pela barra de ferramentas da sessão.
+
+| Instalação necessária | Valores | Padrão | Exemplo |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 O diretório para salvar vídeos gravados.
+
+Para gravações feitas no lado controlado pelo serviço do Windows instalado, use [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Localização**:
 
@@ -455,6 +465,14 @@ Valores padrão:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Nota**: Substitua **app_name** pelo nome atual do aplicativo.
+
+### windows-service-video-save-directory
+
+O diretório onde um cliente Windows instalado salva as gravações quando executado como serviço. O caminho deve ser absoluto. Um caminho vazio ou relativo é ignorado e o RustDesk usa o diretório padrão.
+
+| Instalação necessária | Valores | Padrão | Exemplo |
+| :------: | :------: | :------: | :------: |
+| Y | Caminho absoluto do Windows | `<unidade do sistema>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.ro.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.ro.md
@@ -439,9 +439,19 @@ Puteți verifica [LANGS](https://github.com/rustdesk/rustdesk/blob/master/src/la
 | :------: | :------: | :------: | :------: | :------: |
 | N | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+Ascunde butonul de înregistrare în sesiunile la distanță pe partea care controlează. Această opțiune nu dezactivează înregistrarea. Dacă înregistrarea automată a sesiunilor inițiate este activată, sesiunile sunt înregistrate în continuare, dar utilizatorii nu pot opri înregistrarea din bara de instrumente a sesiunii.
+
+| Install required | Values | Default | Example |
+| :------: | :------: | :------: | :------: |
+| N | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 Directorul în care sunt salvate videoclipurile înregistrate.
+
+Pentru înregistrările realizate pe partea controlată de serviciul Windows instalat, utilizați [`windows-service-video-save-directory`](#windows-service-video-save-directory).
 
 **Locație**:
 
@@ -456,6 +466,14 @@ Valori implicite:
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **Notă**: Înlocuiți **app_name** cu numele aplicației curente.
+
+### windows-service-video-save-directory
+
+Directorul în care un client Windows instalat salvează înregistrările atunci când rulează ca serviciu. Calea trebuie să fie absolută. O cale goală sau relativă este ignorată, iar RustDesk utilizează în schimb directorul implicit.
+
+| Install required | Values | Default | Example |
+| :------: | :------: | :------: | :------: |
+| Y | Absolute Windows path | `<unitate de sistem>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-cn.md
@@ -439,9 +439,19 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 | :------: | :------: | :------: | :------: | :------: |
 | 否 | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+在控制端的远程会话中隐藏录制按钮。这不会禁用录制。如果启用了自动录制传出会话，会话仍会被录制，但用户无法从会话工具栏停止录制。
+
+| 安装需要 | 值 | 默认值 | 示例 |
+| :------: | :------: | :------: | :------: |
+| 否 | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 保存录制视频的目录。
+
+对于已安装的 Windows 服务在被控端进行的录像，请使用 [`windows-service-video-save-directory`](#windows-service-video-save-directory)。
 
 **位置**：
 
@@ -456,6 +466,14 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **注意**：替换**app_name**表示当前应用名称。
+
+### windows-service-video-save-directory
+
+已安装的 Windows 客户端作为服务运行时，用于保存录像的目录。路径必须是绝对路径。空路径或相对路径将被忽略，RustDesk 会改用默认目录。
+
+| 安装需要 | 值 | 默认值 | 示例 |
+| :------: | :------: | :------: | :------: |
+| 是 | Windows 绝对路径 | `<系统盘>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 

--- a/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
+++ b/content/self-host/client-configuration/advanced-settings/_index.zh-tw.md
@@ -439,9 +439,19 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 | :------: | :------: | :------: | :------: | :------: |
 | 否 | Y, N | N | `allow-auto-record-outgoing=Y` | >= 1.3.2 |
 
+### hide-recording-button
+
+在控制端的遠端會話中隱藏錄製按鈕。這不會停用錄製。如果已啟用自動錄製傳出會話，會話仍會被錄製，但使用者無法從會話工具列停止錄製。
+
+| 安裝需要 | 值 | 預設值 | 範例 |
+| :------: | :------: | :------: | :------: |
+| 否 | Y, N | N | `hide-recording-button=Y` |
+
 ### video-save-directory
 
 儲存錄製影片的目錄。
+
+對於已安裝的 Windows 服務在被控端進行的錄影，請使用 [`windows-service-video-save-directory`](#windows-service-video-save-directory)。
 
 **位置**：
 
@@ -456,6 +466,14 @@ ar, bg, ca, cs, da, de, el, en, eo, es, et, fa, fr, he, hr, hu, id, it, ja, ko, 
 4. **Android** /Storage/emulated/0/**app_name**/ScreenRecord
 
 **注意**：替換**app_name**表示目前應用程式名稱。
+
+### windows-service-video-save-directory
+
+已安裝的 Windows 用戶端作為服務執行時，用於儲存錄影的目錄。路徑必須是絕對路徑。空白或相對路徑將被忽略，RustDesk 會改用預設目錄。
+
+| 安裝需要 | 值 | 預設值 | 範例 |
+| :------: | :------: | :------: | :------: |
+| 是 | Windows 絕對路徑 | `<系統磁碟>\ProgramData\<app_name>\recording` | `windows-service-video-save-directory=D:\RustDesk\recordings` |
 
 ### allow-auto-update
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for hiding the recording button during remote sessions without disabling recording.
  - Documented a dedicated recording directory setting for Windows clients running as a service.
  - Clarified that the Windows service recording path must be absolute; empty or relative paths use the default directory.
  - Updated recording directory guidance and examples across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->