### PR TITLE
docs: clarify self-host port usage

### DIFF
--- a/content/self-host/_index.de.md
+++ b/content/self-host/_index.de.md
@@ -41,10 +41,20 @@ Kern-Ports: \
 TCP `21114-21119` \
 UDP `21116`
 
-Die oben genannten `21115-21117` sind die mindestens erforderlichen Ports, damit RustDesk funktioniert. Diese verwalten die Signal- und Relay-Ports sowie die NAT-Traversierung.
+- TCP `21114`: Wird für den HTTP-API-Server in RustDesk Server Pro verwendet.
+- TCP `21115`: Wird für den NAT-Typ-Test verwendet.
+- UDP `21116`: Wird für die Geräteregistrierung verwendet.
+- TCP `21116`: Wird für die Geräteregistrierung und NAT-Hole-Punching verwendet.
+- TCP `21117`: Wird für Relay-Kommunikation verwendet.
+- TCP `21118`: Wird für WebSocket-Kommunikation verwendet.
+- TCP `21119`: Wird für WebSocket-Kommunikation verwendet.
 
-Die TCP-Ports `21118` und `21119` sind die WebSocket-Ports für den [RustDesk Web-Client](https://rustdesk.com/web/). Sie benötigen einen Reverse-Proxy, um HTTPS zu unterstützen. Bitte beachten Sie diese [Beispiel-Nginx-Konfiguration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Ports `21115`-`21117` sind die mindestens erforderlichen Ports, damit RustDesk funktioniert. Diese verwalten Signalisierung, Relay und NAT-Traversierung.
 
-Für Pro-Benutzer ohne SSL-Proxy müssen Sie den TCP-Port `21114` öffnen, damit die API funktioniert. Alternativ können Sie mit einem SSL-Proxy den TCP-Port `443` öffnen.
+Bei einer WSS-Konfiguration müssen TCP `21118` und TCP `21119` in der Regel nicht extern freigegeben werden, da sie intern vom Reverse-Proxy, z. B. Nginx, verwendet werden. Wenn Sie WebSocket nicht verwenden, müssen diese Ports nicht freigegeben werden. Bitte beachten Sie diese [Beispiel-Nginx-Konfiguration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Für Pro-Benutzer ohne SSL-Proxy müssen Sie TCP-Port `21114` öffnen, damit die API funktioniert. Wenn HTTPS (`443`) für den Server konfiguriert ist, muss TCP `21114` nicht im Internet freigegeben werden.
+
+RustDesk unterstützt auch einen Bereitstellungsmodus, bei dem nur TCP `443` freigegeben ist und alle anderen Ports geschlossen sind. Mit dieser Konfiguration kann die Kommunikation nur über WSS-Relay funktionieren, und direkte Peer-to-Peer-Verbindungen sind nicht verfügbar.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.en.md
+++ b/content/self-host/_index.en.md
@@ -46,16 +46,26 @@ Here is a discussion about [Should you self-host a rustdesk server?](https://www
 
 ## Ports Required
 
-Ports required for RustDesk Server self-hosting depends largely on your environment and what you want to do with RustDesk. The Examples shown throughout the docs will generally have all ports suggested to be opened.
+The ports required for RustDesk Server self-hosting depend largely on your environment and what you want to do with RustDesk. The examples shown throughout the docs generally suggest opening all ports.
 
 Core Ports: \
 TCP `21114-21119` \
 UDP `21116`
 
-The above `21115-21117` are the minimum required ports for RustDesk to work, these handle the signal and relay ports as well as NAT traversal.
+- TCP `21114`: Used for the HTTP API server in RustDesk Server Pro.
+- TCP `21115`: Used for the NAT type test.
+- UDP `21116`: Used for device registration.
+- TCP `21116`: Used for device registration and NAT hole punching.
+- TCP `21117`: Used for relay communication.
+- TCP `21118`: Used for WebSocket communication.
+- TCP `21119`: Used for WebSocket communication.
 
-TCP ports `21118` and `21119` are the WebSocket ports for the [RustDesk Web Client](https://rustdesk.com/web/), you need a reverse proxy to make it support HTTPS, please refer this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Ports `21115`-`21117` are the minimum required ports for RustDesk to work. These handle signal, relay, and NAT traversal.
 
-For Pro users without an SSL Proxy you will need to open TCP port `21114` for the API to work alternatively using an SSL Proxy open TCP port `443`.
+For WSS configuration, TCP `21118` and TCP `21119` usually do not need to be exposed externally because they are accessed internally by the reverse proxy, such as Nginx. If you do not use WebSocket, these ports do not need to be exposed. Please refer to this [sample Nginx configuration](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+For Pro users without an SSL proxy, you need to open TCP port `21114` for the API to work. If HTTPS (`443`) is configured for the server, TCP `21114` does not need to be exposed to the Internet.
+
+RustDesk also supports a deployment mode where only TCP `443` is exposed and all other ports are closed. With this configuration, communication can only work through WSS relay, and direct peer-to-peer connections are not available.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.es.md
+++ b/content/self-host/_index.es.md
@@ -41,10 +41,20 @@ Puertos Principales: \
 TCP `21114-21119` \
 UDP `21116`
 
-Los `21115-21117` anteriores son los puertos mínimos requeridos para que RustDesk funcione, estos manejan los puertos de señal y retransmisión así como la traversía NAT.
+- TCP `21114`: Se usa para el servidor API HTTP en RustDesk Server Pro.
+- TCP `21115`: Se usa para la prueba de tipo de NAT.
+- UDP `21116`: Se usa para el registro de dispositivos.
+- TCP `21116`: Se usa para el registro de dispositivos y la perforación NAT.
+- TCP `21117`: Se usa para la comunicación de retransmisión.
+- TCP `21118`: Se usa para la comunicación WebSocket.
+- TCP `21119`: Se usa para la comunicación WebSocket.
 
-Los puertos TCP `21118` y `21119` son los puertos WebSocket para el [Cliente Web RustDesk](https://rustdesk.com/web/), necesitas un proxy reverso para hacer que soporte HTTPS, por favor consulta esta [configuración de ejemplo de Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Los puertos `21115`-`21117` son los puertos mínimos requeridos para que RustDesk funcione. Estos manejan señalización, retransmisión y travesía NAT.
 
-Para usuarios Pro sin un Proxy SSL necesitarás abrir el puerto TCP `21114` para que la API funcione alternativamente usando un Proxy SSL abre el puerto TCP `443`.
+Para una configuración WSS, los puertos TCP `21118` y TCP `21119` normalmente no necesitan exponerse externamente porque el proxy inverso, como Nginx, accede a ellos internamente. Si no usas WebSocket, estos puertos no necesitan exponerse. Consulta esta [configuración de ejemplo de Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Para usuarios Pro sin un proxy SSL, debes abrir el puerto TCP `21114` para que la API funcione. Si HTTPS (`443`) está configurado para el servidor, TCP `21114` no necesita exponerse a Internet.
+
+RustDesk también admite un modo de despliegue en el que solo se expone TCP `443` y todos los demás puertos están cerrados. Con esta configuración, la comunicación solo puede funcionar mediante retransmisión WSS, y las conexiones directas punto a punto no están disponibles.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.fr.md
+++ b/content/self-host/_index.fr.md
@@ -41,10 +41,20 @@ Ports principaux : \
 TCP `21114-21119` \
 UDP `21116`
 
-Les ports `21115-21117` ci-dessus sont les ports minimum requis pour que RustDesk fonctionne, ils gèrent les ports de signal et de relais ainsi que la traversée NAT.
+- TCP `21114` : utilisé pour le serveur API HTTP dans RustDesk Server Pro.
+- TCP `21115` : utilisé pour le test du type NAT.
+- UDP `21116` : utilisé pour l'enregistrement des appareils.
+- TCP `21116` : utilisé pour l'enregistrement des appareils et le NAT hole punching.
+- TCP `21117` : utilisé pour la communication relais.
+- TCP `21118` : utilisé pour la communication WebSocket.
+- TCP `21119` : utilisé pour la communication WebSocket.
 
-Les ports TCP `21118` et `21119` sont les ports WebSocket pour le [client Web RustDesk](https://rustdesk.com/web/), vous avez besoin d'un proxy inverse pour le faire supporter HTTPS, veuillez vous référer à cet [exemple de configuration Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Les ports `21115`-`21117` sont les ports minimum requis pour que RustDesk fonctionne. Ils gèrent la signalisation, le relais et la traversée NAT.
 
-Pour les utilisateurs Pro sans proxy SSL, vous devrez ouvrir le port TCP `21114` pour que l'API fonctionne, ou utiliser un proxy SSL pour ouvrir le port TCP `443`.
+Pour une configuration WSS, les ports TCP `21118` et TCP `21119` n'ont généralement pas besoin d'être exposés à l'extérieur, car ils sont utilisés en interne par le proxy inverse, tel que Nginx. Si vous n'utilisez pas WebSocket, ces ports n'ont pas besoin d'être exposés. Veuillez vous référer à cet [exemple de configuration Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Pour les utilisateurs Pro sans proxy SSL, vous devez ouvrir le port TCP `21114` pour que l'API fonctionne. Si HTTPS (`443`) est configuré pour le serveur, TCP `21114` n'a pas besoin d'être exposé à Internet.
+
+RustDesk prend également en charge un mode de déploiement où seul TCP `443` est exposé et tous les autres ports sont fermés. Avec cette configuration, la communication ne peut fonctionner que via le relais WSS, et les connexions directes pair-à-pair ne sont pas disponibles.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.it.md
+++ b/content/self-host/_index.it.md
@@ -41,10 +41,20 @@ Porte Principali: \
 TCP `21114-21119` \
 UDP `21116`
 
-Le `21115-21117` sopra sono le porte minime richieste per far funzionare RustDesk, queste gestiscono le porte di segnale e relay così come l'attraversamento NAT.
+- TCP `21114`: Usata per il server API HTTP in RustDesk Server Pro.
+- TCP `21115`: Usata per il test del tipo NAT.
+- UDP `21116`: Usata per la registrazione dei dispositivi.
+- TCP `21116`: Usata per la registrazione dei dispositivi e il NAT hole punching.
+- TCP `21117`: Usata per la comunicazione relay.
+- TCP `21118`: Usata per la comunicazione WebSocket.
+- TCP `21119`: Usata per la comunicazione WebSocket.
 
-Le porte TCP `21118` e `21119` sono le porte WebSocket per il [Client Web RustDesk](https://rustdesk.com/web/), hai bisogno di un reverse proxy per farlo supportare HTTPS, per favore fai riferimento a questa [configurazione di esempio Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Le porte `21115`-`21117` sono le porte minime richieste per far funzionare RustDesk. Gestiscono segnalazione, relay e attraversamento NAT.
 
-Per gli utenti Pro senza un Proxy SSL dovrai aprire la porta TCP `21114` perché l'API funzioni alternativamente usando un Proxy SSL apri la porta TCP `443`.
+Per una configurazione WSS, le porte TCP `21118` e TCP `21119` di solito non devono essere esposte esternamente perché vengono usate internamente dal reverse proxy, come Nginx. Se non usi WebSocket, queste porte non devono essere esposte. Fai riferimento a questa [configurazione di esempio Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Per gli utenti Pro senza un proxy SSL, devi aprire la porta TCP `21114` perché l'API funzioni. Se HTTPS (`443`) è configurato per il server, TCP `21114` non deve essere esposto a Internet.
+
+RustDesk supporta anche una modalità di distribuzione in cui è esposto solo TCP `443` e tutte le altre porte sono chiuse. Con questa configurazione, la comunicazione può funzionare solo tramite relay WSS e le connessioni peer-to-peer dirette non sono disponibili.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.ja.md
+++ b/content/self-host/_index.ja.md
@@ -41,10 +41,20 @@ RustDesk サーバーのセルフホスティングに必要なポートは、�
 TCP `21114-21119` \
 UDP `21116`
 
-上記の `21115-21117` は RustDesk が動作するために必要な最小ポートで、これらはシグナルとリレーポートおよび NAT トラバーサルを処理します。
+- TCP `21114`: RustDesk Server Pro の HTTP API サーバーに使用されます。
+- TCP `21115`: NAT タイプテストに使用されます。
+- UDP `21116`: デバイス登録に使用されます。
+- TCP `21116`: デバイス登録と NAT ホールパンチングに使用されます。
+- TCP `21117`: リレー通信に使用されます。
+- TCP `21118`: WebSocket 通信に使用されます。
+- TCP `21119`: WebSocket 通信に使用されます。
 
-TCP ポート `21118` と `21119` は [RustDesk Web クライアント](https://rustdesk.com/web/)の WebSocket ポートで、HTTPS をサポートするにはリバースプロキシが必要です。この[サンプル Nginx 設定](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client)を参照してください。
+ポート `21115`-`21117` は RustDesk が動作するために必要な最小ポートです。これらはシグナリング、リレー、NAT トラバーサルを処理します。
 
-SSL プロキシなしの Pro ユーザーの場合、API が動作するように TCP ポート `21114` を開く必要があります。または、SSL プロキシを使用して TCP ポート `443` を開いてください。
+WSS 構成では、TCP `21118` と TCP `21119` は通常、Nginx などのリバースプロキシから内部的にアクセスされるため、外部に公開する必要はありません。WebSocket を使用しない場合も、これらのポートを公開する必要はありません。この[サンプル Nginx 設定](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms)を参照してください。
+
+SSL プロキシなしの Pro ユーザーの場合、API を動作させるには TCP ポート `21114` を開く必要があります。サーバーに HTTPS (`443`) が設定されている場合、TCP `21114` を Internet に公開する必要はありません。
+
+RustDesk は、TCP `443` のみを公開し、他のすべてのポートを閉じるデプロイモードにも対応しています。この構成では、通信は WSS リレー経由でのみ動作し、直接ピアツーピア接続は利用できません。
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.ko.md
+++ b/content/self-host/_index.ko.md
@@ -48,10 +48,20 @@ RustDesk 서버 자체 호스팅에 필요한 포트는 주로 귀하의 환경�
 TCP `21114-21119` \
 UDP `21116`
 
-위의 `21115-21117`는 RustDesk가 작동하는 데 필요한 최소한의 포트이며, 이들은 신호 및 릴레이 포트와 NAT 트래버스를 처리합니다.
+- TCP `21114`: RustDesk Server Pro의 HTTP API 서버에 사용됩니다.
+- TCP `21115`: NAT 유형 테스트에 사용됩니다.
+- UDP `21116`: 장치 등록에 사용됩니다.
+- TCP `21116`: 장치 등록 및 NAT 홀 펀칭에 사용됩니다.
+- TCP `21117`: 릴레이 통신에 사용됩니다.
+- TCP `21118`: WebSocket 통신에 사용됩니다.
+- TCP `21119`: WebSocket 통신에 사용됩니다.
 
-TCP 포트 `21118` 및 `21119`는 [RustDesk Web Client](https://rustdesk.com/web/)의 웹소켓 포트이며, HTTPS를 지원하려면 역방향 프록시가 필요합니다. 이 [sample Nginx configuration](/docs/ko/self-host/rustdesk-server-pro/faq/#8-id-서버와-릴레이-서버에-websocket-secure-wss-지원을-추가하여-모든-플랫폼에서-안전한-통신을-가능하게-하십시오)를 참조하십시오.
+포트 `21115`-`21117`는 RustDesk가 작동하는 데 필요한 최소 포트입니다. 이 포트들은 신호, 릴레이 및 NAT 트래버스를 처리합니다.
 
-SSL 프록시가 없는 Pro 사용자의 경우 API가 작동하려면 TCP 포트 `21114`를 열어야 하며, 대신 SSL 프록시를 사용하여 TCP 포트 `443`를 열어야 합니다.
+WSS 구성에서는 TCP `21118` 및 TCP `21119`가 일반적으로 Nginx 같은 역방향 프록시에서 내부적으로 접근되므로 외부에 노출할 필요가 없습니다. WebSocket을 사용하지 않는 경우에도 이 포트들을 노출할 필요가 없습니다. 이 [sample Nginx configuration](/docs/ko/self-host/rustdesk-server-pro/faq/#8-id-서버와-릴레이-서버에-websocket-secure-wss-지원을-추가하여-모든-플랫폼에서-안전한-통신을-가능하게-하십시오)를 참조하십시오.
+
+SSL 프록시가 없는 Pro 사용자의 경우 API가 작동하려면 TCP 포트 `21114`를 열어야 합니다. 서버에 HTTPS (`443`)가 구성되어 있으면 TCP `21114`를 인터넷에 노출할 필요가 없습니다.
+
+RustDesk는 TCP `443`만 노출하고 다른 모든 포트를 닫는 배포 모드도 지원합니다. 이 구성에서는 통신이 WSS 릴레이를 통해서만 작동할 수 있으며 직접 P2P 연결은 사용할 수 없습니다.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.pl.md
+++ b/content/self-host/_index.pl.md
@@ -41,10 +41,20 @@ Główne porty: \
 TCP `21114-21119` \
 UDP `21116`
 
-Powyższy zakres `21115-21117` to minimum portów potrzebnych RustDeskowi do działania. To one zajmują się sygnalizowaniem i przekazywaniem oraz przechodzeniem przez NAT.
+- TCP `21114`: używany przez serwer HTTP API w RustDesk Server Pro.
+- TCP `21115`: używany do testu typu NAT.
+- UDP `21116`: używany do rejestracji urządzeń.
+- TCP `21116`: używany do rejestracji urządzeń i NAT hole punching.
+- TCP `21117`: używany do komunikacji relay.
+- TCP `21118`: używany do komunikacji WebSocket.
+- TCP `21119`: używany do komunikacji WebSocket.
 
-Porty TCP `21118` i `21119` są portami WebSocketów dla [klienta webowego RustDeska](https://rustdesk.com/web/). Potrzebujesz wstecznego proxy, jeżeli chcesz używać HTTPS - zobacz [przykładową konfigurację Nginxa](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Porty `21115`-`21117` to minimum portów potrzebnych RustDeskowi do działania. Obsługują sygnalizację, relay i przechodzenie przez NAT.
 
-Użytkownicy Pro bez proxy SSL będą potrzebowali otworzyć port TCP `21114` żeby API było w stanie funckjonować - alternatywnie użyj proxy SSL i otwórz port `443`. 
+Przy konfiguracji WSS porty TCP `21118` i TCP `21119` zwykle nie muszą być wystawione na zewnątrz, ponieważ są używane wewnętrznie przez reverse proxy, takie jak Nginx. Jeśli nie używasz WebSocket, tych portów nie trzeba wystawiać. Zobacz [przykładową konfigurację Nginxa](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Użytkownicy Pro bez proxy SSL muszą otworzyć port TCP `21114`, aby API działało. Jeśli HTTPS (`443`) jest skonfigurowany dla serwera, TCP `21114` nie musi być wystawiony do Internetu.
+
+RustDesk obsługuje też tryb wdrożenia, w którym wystawiony jest tylko TCP `443`, a wszystkie pozostałe porty są zamknięte. W tej konfiguracji komunikacja może działać tylko przez relay WSS, a bezpośrednie połączenia peer-to-peer nie są dostępne.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.pt.md
+++ b/content/self-host/_index.pt.md
@@ -41,10 +41,20 @@ Portas Principais: \
 TCP `21114-21119` \
 UDP `21116`
 
-As `21115-21117` acima são as portas mínimas necessárias para o RustDesk funcionar, estas lidam com as portas de sinal e retransmissão bem como travessia NAT.
+- TCP `21114`: Usada para o servidor API HTTP no RustDesk Server Pro.
+- TCP `21115`: Usada para o teste de tipo NAT.
+- UDP `21116`: Usada para registro de dispositivos.
+- TCP `21116`: Usada para registro de dispositivos e NAT hole punching.
+- TCP `21117`: Usada para comunicação de retransmissão.
+- TCP `21118`: Usada para comunicação WebSocket.
+- TCP `21119`: Usada para comunicação WebSocket.
 
-As portas TCP `21118` e `21119` são as portas WebSocket para o [Cliente Web RustDesk](https://rustdesk.com/web/), você precisa de um proxy reverso para fazê-lo suportar HTTPS, por favor consulte esta [configuração de exemplo do Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+As portas `21115`-`21117` são as portas mínimas necessárias para o RustDesk funcionar. Elas lidam com sinalização, retransmissão e travessia NAT.
 
-Para usuários Pro sem um Proxy SSL você precisará abrir a porta TCP `21114` para a API funcionar, alternativamente usando um Proxy SSL abra a porta TCP `443`.
+Para configuração WSS, as portas TCP `21118` e TCP `21119` geralmente não precisam ser expostas externamente porque são acessadas internamente pelo proxy reverso, como o Nginx. Se você não usa WebSocket, essas portas não precisam ser expostas. Consulte esta [configuração de exemplo do Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Para usuários Pro sem um proxy SSL, você precisa abrir a porta TCP `21114` para que a API funcione. Se HTTPS (`443`) estiver configurado para o servidor, TCP `21114` não precisa ser exposto à Internet.
+
+O RustDesk também oferece suporte a um modo de implantação em que apenas TCP `443` é exposto e todas as outras portas ficam fechadas. Com essa configuração, a comunicação só pode funcionar por retransmissão WSS, e conexões diretas ponto a ponto não ficam disponíveis.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.ro.md
+++ b/content/self-host/_index.ro.md
@@ -41,10 +41,20 @@ Porturi de bază: \
 TCP `21114-21119` \
 UDP `21116`
 
-Porturile `21115-21117` sunt minimul necesar pentru funcționarea RustDesk; acestea gestionează semnalizarea, porturile de relay și traversarea NAT.
+- TCP `21114`: folosit pentru serverul HTTP API în RustDesk Server Pro.
+- TCP `21115`: folosit pentru testul tipului NAT.
+- UDP `21116`: folosit pentru înregistrarea dispozitivelor.
+- TCP `21116`: folosit pentru înregistrarea dispozitivelor și NAT hole punching.
+- TCP `21117`: folosit pentru comunicarea relay.
+- TCP `21118`: folosit pentru comunicarea WebSocket.
+- TCP `21119`: folosit pentru comunicarea WebSocket.
 
-Porturile TCP `21118` și `21119` sunt porturile WebSocket pentru [RustDesk Web Client](https://rustdesk.com/web/). Aveți nevoie de un reverse proxy pentru a suporta HTTPS; consultați acest [exemplu de configurare Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client).
+Porturile `21115`-`21117` sunt minimul necesar pentru funcționarea RustDesk. Acestea gestionează semnalizarea, relay-ul și traversarea NAT.
 
-Pentru utilizatorii Pro fără un SSL Proxy va fi necesar să deschideți portul TCP `21114` pentru ca API-ul să funcționeze; alternativ, folosind un SSL Proxy se va deschide portul TCP `443`.
+Pentru o configurație WSS, porturile TCP `21118` și TCP `21119` de obicei nu trebuie expuse extern, deoarece sunt accesate intern de reverse proxy, cum ar fi Nginx. Dacă nu utilizați WebSocket, aceste porturi nu trebuie expuse. Consultați acest [exemplu de configurare Nginx](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms).
+
+Pentru utilizatorii Pro fără un proxy SSL, trebuie să deschideți portul TCP `21114` pentru ca API-ul să funcționeze. Dacă HTTPS (`443`) este configurat pentru server, TCP `21114` nu trebuie expus pe Internet.
+
+RustDesk suportă și un mod de implementare în care doar TCP `443` este expus și toate celelalte porturi sunt închise. Cu această configurație, comunicarea poate funcționa doar prin relay WSS, iar conexiunile directe peer-to-peer nu sunt disponibile.
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.zh-cn.md
+++ b/content/self-host/_index.zh-cn.md
@@ -41,10 +41,20 @@ RustDesk 服务器自托管所需的端口很大程度上取决于您的环境�
 TCP `21114-21119` \
 UDP `21116`
 
-上述 `21115-21117` 是 RustDesk 工作所需的最小端口，这些处理信号和中继端口以及 NAT 穿越。
+- TCP `21114`：用于 RustDesk Server Pro 中的 HTTP API 服务器。
+- TCP `21115`：用于 NAT 类型测试。
+- UDP `21116`：用于设备注册。
+- TCP `21116`：用于设备注册和 NAT 打洞。
+- TCP `21117`：用于中继通信。
+- TCP `21118`：用于 WebSocket 通信。
+- TCP `21119`：用于 WebSocket 通信。
 
-TCP 端口 `21118` 和 `21119` 是 [RustDesk Web 客户端](https://rustdesk.com/web/)的 WebSocket 端口，您需要反向代理来使其支持 HTTPS，请参考这个[示例 Nginx 配置](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client)。
+`21115`-`21117` 是 RustDesk 工作所需的最小端口。这些端口处理信令、中继和 NAT 穿透。
 
-对于没有 SSL 代理的专业版用户，您需要打开 TCP 端口 `21114` 以使 API 工作，或者使用 SSL 代理打开 TCP 端口 `443`。
+对于 WSS 配置，TCP `21118` 和 TCP `21119` 通常不需要对外暴露，因为它们通常由 Nginx 等反向代理在内部访问。如果您不使用 WebSocket，也不需要暴露这些端口。请参考这个[示例 Nginx 配置](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms)。
+
+对于没有 SSL 代理的专业版用户，您需要打开 TCP 端口 `21114` 以使 API 工作。如果服务器已配置 HTTPS (`443`)，TCP `21114` 不需要暴露到 Internet。
+
+RustDesk 还支持仅暴露 TCP `443` 并关闭所有其他端口的部署模式。使用此配置时，通信只能通过 WSS 中继进行，无法使用直接点对点连接。
 
 {{% children depth="4" showhidden="true" %}}

--- a/content/self-host/_index.zh-tw.md
+++ b/content/self-host/_index.zh-tw.md
@@ -41,10 +41,20 @@ ID 伺服器然後嘗試使用打洞技術將 A 和 B 直接連接。
 TCP `21114-21119` \
 UDP `21116`
 
-上述的 `21115-21117` 是 RustDesk 運作所需的最低要求連接埠，這些處理信號和中繼連接埠以及 NAT 穿透。
+- TCP `21114`：用於 RustDesk Server Pro 中的 HTTP API 伺服器。
+- TCP `21115`：用於 NAT 類型測試。
+- UDP `21116`：用於裝置註冊。
+- TCP `21116`：用於裝置註冊和 NAT 打洞。
+- TCP `21117`：用於中繼通訊。
+- TCP `21118`：用於 WebSocket 通訊。
+- TCP `21119`：用於 WebSocket 通訊。
 
-TCP 連接埠 `21118` 和 `21119` 是 [RustDesk Web 客戶端](https://rustdesk.com/web/)的 WebSocket 連接埠，您需要反向代理來支援 HTTPS，請參考這個 [Nginx 配置範例](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-the-web-client)。
+`21115`-`21117` 是 RustDesk 運作所需的最低要求連接埠。這些連接埠處理信號、中繼和 NAT 穿透。
 
-對於沒有 SSL 代理的專業版用戶，您需要開啟 TCP 連接埠 `21114` 以使 API 運作，或者使用 SSL 代理開啟 TCP 連接埠 `443`。
+對於 WSS 設定，TCP `21118` 和 TCP `21119` 通常不需要對外暴露，因為它們通常由 Nginx 等反向代理在內部存取。如果您不使用 WebSocket，也不需要暴露這些連接埠。請參考這個 [Nginx 設定範例](/docs/en/self-host/rustdesk-server-pro/faq/#8-add-websocket-secure-wss-support-for-the-id-server-and-relay-server-to-enable-secure-communication-for-all-platforms)。
+
+對於沒有 SSL 代理的 Pro 使用者，您需要開啟 TCP 連接埠 `21114` 讓 API 運作。如果伺服器已設定 HTTPS (`443`)，TCP `21114` 不需要暴露到 Internet。
+
+RustDesk 也支援僅暴露 TCP `443` 並關閉所有其他連接埠的部署模式。在此設定下，通訊只能透過 WSS 中繼進行，無法使用直接點對點連線。
 
 {{% children depth="4" showhidden="true" %}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded self-hosting port guidance with the purpose of each port and the minimum required ports.
  - Clarified WebSocket exposure requirements for WSS and reverse-proxy setups.
  - Added guidance for Pro API access, HTTPS configurations, and TCP 443-only deployments.
  - Documented that 443-only relay mode does not support direct peer-to-peer connections.
  - Updated the guidance across all supported translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->