### PR TITLE
docs(relay): document hbbr key configuration options

### DIFF
--- a/content/self-host/rustdesk-server-pro/relay/_index.de.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.de.md
@@ -31,7 +31,44 @@ Wenn Sie einen zusätzlichen Relay-Server explizit auf einem anderen Rechner ein
 
 Sie können mehrere Relay-Server auf der ganzen Welt betreiben und GeoLocation nutzen, um den nächstgelegenen Relay-Server zu verwenden, sodass Sie eine schnellere Verbindung zu entfernten Computern herstellen können.
 
-> Sie benötigen das private Schlüsselpaar `id_ed25519` und `id_ed25519.pub`.
+> Setzen Sie die Umgebungsvariable `KEY` von `hbbr` auf den öffentlichen Schlüssel in `id_ed25519.pub`, oder kopieren Sie `id_ed25519` und `id_ed25519.pub` auf den Relay-Server.
+
+### Docker Compose
+
+Ein zusätzlicher Relay-Server benötigt nur `hbbr`; `hbbs` und `depends_on` sind nicht erforderlich. Wählen Sie eine der folgenden Methoden zur Schlüsselkonfiguration:
+
+- Behalten Sie den Abschnitt `environment` bei und setzen Sie `KEY` wie unten gezeigt auf den Inhalt von `id_ed25519.pub`.
+- Entfernen Sie den gesamten Abschnitt `environment` und legen Sie `id_ed25519` sowie `id_ed25519.pub` in `./data` ab.
+
+Erstellen Sie eine Datei namens `compose.yml` mit dem folgenden Inhalt.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Schlüssel mit einer Umgebungsvariable festlegen
+
+Setzen Sie `KEY` auf den Inhalt von `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Schlüsseldateien verwenden
+
+Das folgende Docker-Beispiel verwendet die Schlüsseldatei-Methode.
 
 1 - Wenn Docker bereits installiert ist, verbinden Sie sich über SSH mit Ihrem Server und erstellen Sie ein Volume für hbbr.
 
@@ -53,8 +90,18 @@ Die Befehlssyntax lautet: `scp <path/filename> username@server:</destination/pat
 3 - Stellen Sie den hbbr-Container unter Verwendung des zuvor erstellten Volumes bereit. Dieses Volume enthält das private Schlüsselpaar, das für die Ausführung Ihres privaten Relay-Servers benötigt wird.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+Das Image `rustdesk/rustdesk-server` akzeptiert weiterhin `-k <KEY>`. Um die eingebundene Schlüsseldatei zu verwenden, starten Sie es mit `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Dabei ist `_` ein spezieller Wert und nicht der Schlüssel selbst. Er weist `hbbr` an, `id_ed25519` zu laden oder zu erzeugen, daraus den öffentlichen Schlüssel abzuleiten und mit diesem Schlüssel Relay-Anfragen zu prüfen. RustDesk Server Pro-Versionen vor 1.8.6 akzeptierten ebenfalls `-k _`, um `id_ed25519` zu laden.
+
+Ab RustDesk Server Pro 1.8.6 ist die Option `-k` für `hbbr` veraltet und wird ignoriert. Wenn `KEY` nicht gesetzt ist, leitet `hbbr` den öffentlichen Schlüssel aus `id_ed25519` ab oder liest ihn aus `id_ed25519.pub`, wenn die private Schlüsseldatei nicht vorhanden ist. Wenn keine der beiden Dateien vorhanden ist, läuft `hbbr` im öffentlichen Relay-Modus.
 
 4 - Überprüfen Sie in den Logs, ob hbbr mit Ihrem Schlüsselpaar läuft.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.en.md
@@ -14,7 +14,7 @@ You need additional relay servers when users connect across regions and direct h
 ## Relay setup checklist
 
 1. Deploy an extra `hbbr` relay server in the target region.
-2. Copy the `id_ed25519` and `id_ed25519.pub` key pair to that relay server.
+2. Set the `KEY` environment variable on `hbbr` to the public key in `id_ed25519.pub`, or copy `id_ed25519` and `id_ed25519.pub` to the relay server.
 3. Open TCP ports `21117` and `21119`.
 4. Add the new relay hostnames or IP addresses in the RustDesk Pro web console.
 5. Install the MaxMind GeoLite2 City database on `hbbs`.
@@ -36,7 +36,44 @@ You can have several relay servers running across the globe and leverage GeoLoca
 Known issue: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> You will need the private key pair `id_ed25519` and `id_ed25519.pub`.
+> Set the `KEY` environment variable on `hbbr` to the public key in `id_ed25519.pub`, or copy `id_ed25519` and `id_ed25519.pub` to the relay server.
+
+### Docker Compose
+
+An additional relay server only needs `hbbr`; `hbbs` and `depends_on` are not required. Choose one of the following key configuration methods:
+
+- Keep the `environment` section and set `KEY` to the contents of `id_ed25519.pub`, as shown below.
+- Remove the entire `environment` section and put `id_ed25519` and `id_ed25519.pub` in `./data`.
+
+Create a `compose.yml` file with the following content.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Set the key with an environment variable
+
+Set `KEY` to the contents of `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Use key files
+
+The Docker example below uses the key-file method.
 
 1 - If docker is already installed, connect to your server via SSH and create a volume for hbbr.
 
@@ -58,8 +95,18 @@ The command syntax is `scp <path/filename> username@server:</destination/path>`.
 3 - Deploy the hbbr container using the volume previously created. This volume has the private key pair needed to run your private relay server.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+The `rustdesk/rustdesk-server` image still accepts `-k <KEY>`. To use the mounted key file, run it with `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Here, `_` is a special value rather than the key itself. It tells `hbbr` to load or generate `id_ed25519`, derive its public key, and use that key to validate relay requests. RustDesk Server Pro versions earlier than 1.8.6 also accepted `-k _` to load `id_ed25519`.
+
+Starting with RustDesk Server Pro 1.8.6, the `-k` option for `hbbr` is deprecated and ignored. If `KEY` is not set, `hbbr` derives the public key from `id_ed25519`, or reads it from `id_ed25519.pub` if the private key file does not exist. If neither file exists, `hbbr` runs in public relay mode.
 
 4 - Check the running logs to verify that hbbr is running using your key pair.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.es.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.es.md
@@ -35,7 +35,44 @@ Puede tener varios servidores de relé ejecutándose por todo el mundo y aprovec
 Problema conocido: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Necesitará el par de claves privadas `id_ed25519` y `id_ed25519.pub`.
+> Establezca la variable de entorno `KEY` de `hbbr` en la clave pública de `id_ed25519.pub`, o copie `id_ed25519` e `id_ed25519.pub` en el servidor de retransmisión.
+
+### Docker Compose
+
+Un servidor de retransmisión adicional solo necesita `hbbr`; no se requieren `hbbs` ni `depends_on`. Elija uno de los siguientes métodos de configuración de la clave:
+
+- Mantenga la sección `environment` y establezca `KEY` en el contenido de `id_ed25519.pub`, como se muestra a continuación.
+- Elimine toda la sección `environment` y coloque `id_ed25519` e `id_ed25519.pub` en `./data`.
+
+Cree un archivo `compose.yml` con el siguiente contenido.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Establecer la clave mediante una variable de entorno
+
+Establezca `KEY` en el contenido de `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Usar archivos de claves
+
+El siguiente ejemplo de Docker utiliza el método de archivos de claves.
 
 1 - Si docker ya está instalado, conéctese a su servidor a través de SSH y cree un volumen para hbbr.
 
@@ -57,8 +94,18 @@ La sintaxis del comando es `scp <ruta/nombre_archivo> usuario@servidor:</ruta/de
 3 - Despliegue el contenedor hbbr usando el volumen creado previamente. Este volumen tiene el par de claves privadas necesario para ejecutar su servidor de relé privado.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+La imagen `rustdesk/rustdesk-server` sigue aceptando `-k <KEY>`. Para utilizar el archivo de clave montado, ejecútela con `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Aquí, `_` es un valor especial, no la clave en sí. Indica a `hbbr` que cargue o genere `id_ed25519`, obtenga su clave pública y la utilice para validar las solicitudes de retransmisión. Las versiones de RustDesk Server Pro anteriores a 1.8.6 también aceptaban `-k _` para cargar `id_ed25519`.
+
+A partir de RustDesk Server Pro 1.8.6, la opción `-k` de `hbbr` está obsoleta y se ignora. Si `KEY` no está definida, `hbbr` obtiene la clave pública de `id_ed25519` o la lee de `id_ed25519.pub` si el archivo de clave privada no existe. Si no existe ninguno de los dos archivos, `hbbr` se ejecuta en modo de retransmisión público.
 
 4 - Verifique los registros de ejecución para verificar que hbbr está ejecutándose usando su par de claves.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.fr.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.fr.md
@@ -35,7 +35,44 @@ Vous pouvez avoir plusieurs serveurs de relais fonctionnant à travers le globe 
 Problème connu : https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Vous aurez besoin de la paire de clés privées `id_ed25519` et `id_ed25519.pub`.
+> Définissez la variable d’environnement `KEY` de `hbbr` sur la clé publique contenue dans `id_ed25519.pub`, ou copiez `id_ed25519` et `id_ed25519.pub` sur le serveur de relais.
+
+### Docker Compose
+
+Un serveur de relais supplémentaire n’a besoin que de `hbbr` ; `hbbs` et `depends_on` ne sont pas nécessaires. Choisissez l’une des méthodes de configuration de clé suivantes :
+
+- Conservez la section `environment` et définissez `KEY` sur le contenu de `id_ed25519.pub`, comme illustré ci-dessous.
+- Supprimez toute la section `environment` et placez `id_ed25519` et `id_ed25519.pub` dans `./data`.
+
+Créez un fichier `compose.yml` avec le contenu suivant.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Définir la clé avec une variable d’environnement
+
+Définissez `KEY` sur le contenu de `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Utiliser les fichiers de clés
+
+L’exemple Docker ci-dessous utilise la méthode des fichiers de clés.
 
 1 - Si docker est déjà installé, connectez-vous à votre serveur via SSH et créez un volume pour hbbr.
 
@@ -57,8 +94,18 @@ La syntaxe de la commande est `scp <chemin/nom_fichier> nom_utilisateur@serveur:
 3 - Déployez le conteneur hbbr en utilisant le volume précédemment créé. Ce volume contient la paire de clés privées nécessaire pour exécuter votre serveur de relais privé.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+L’image `rustdesk/rustdesk-server` accepte toujours `-k <KEY>`. Pour utiliser le fichier de clé monté, exécutez-la avec `-k _` :
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Ici, `_` est une valeur spéciale, et non la clé elle-même. Elle indique à `hbbr` de charger ou générer `id_ed25519`, d’en dériver la clé publique et d’utiliser cette clé pour valider les demandes de relais. Les versions de RustDesk Server Pro antérieures à 1.8.6 acceptaient également `-k _` pour charger `id_ed25519`.
+
+À partir de RustDesk Server Pro 1.8.6, l’option `-k` de `hbbr` est obsolète et ignorée. Si `KEY` n’est pas définie, `hbbr` dérive la clé publique de `id_ed25519` ou la lit dans `id_ed25519.pub` si le fichier de clé privée n’existe pas. Si aucun des deux fichiers n’existe, `hbbr` fonctionne en mode relais public.
 
 4 - Vérifiez les journaux d'exécution pour vérifier que hbbr fonctionne en utilisant votre paire de clés.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.it.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.it.md
@@ -35,7 +35,44 @@ Puoi avere diversi server di relay in esecuzione in tutto il mondo e sfruttare l
 Problema noto: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Avrai bisogno della coppia di chiavi private `id_ed25519` e `id_ed25519.pub`.
+> Imposta la variabile d'ambiente `KEY` di `hbbr` sulla chiave pubblica contenuta in `id_ed25519.pub`, oppure copia `id_ed25519` e `id_ed25519.pub` sul server relay.
+
+### Docker Compose
+
+Un server relay aggiuntivo richiede solo `hbbr`; `hbbs` e `depends_on` non sono necessari. Scegli uno dei seguenti metodi di configurazione della chiave:
+
+- Mantieni la sezione `environment` e imposta `KEY` sul contenuto di `id_ed25519.pub`, come mostrato di seguito.
+- Rimuovi l’intera sezione `environment` e inserisci `id_ed25519` e `id_ed25519.pub` in `./data`.
+
+Crea un file `compose.yml` con il seguente contenuto.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Impostare la chiave con una variabile d'ambiente
+
+Imposta `KEY` sul contenuto di `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Usare i file delle chiavi
+
+L'esempio Docker seguente utilizza il metodo dei file delle chiavi.
 
 1 - Se docker è già installato, connettiti al tuo server via SSH e crea un volume per hbbr.
 
@@ -57,8 +94,18 @@ La sintassi del comando è `scp <percorso/nome_file> username@server:</percorso/
 3 - Distribuisci il container hbbr usando il volume creato precedentemente. Questo volume ha la coppia di chiavi private necessaria per eseguire il tuo server di relay privato.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+L'immagine `rustdesk/rustdesk-server` accetta ancora `-k <KEY>`. Per utilizzare il file della chiave montato, eseguila con `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+In questo caso, `_` è un valore speciale e non la chiave stessa. Indica a `hbbr` di caricare o generare `id_ed25519`, ricavarne la chiave pubblica e utilizzare tale chiave per convalidare le richieste di relay. Anche le versioni di RustDesk Server Pro precedenti alla 1.8.6 accettavano `-k _` per caricare `id_ed25519`.
+
+A partire da RustDesk Server Pro 1.8.6, l'opzione `-k` di `hbbr` è deprecata e viene ignorata. Se `KEY` non è impostata, `hbbr` ricava la chiave pubblica da `id_ed25519` oppure la legge da `id_ed25519.pub` se il file della chiave privata non esiste. Se nessuno dei due file esiste, `hbbr` viene eseguito in modalità relay pubblica.
 
 4 - Controlla i log di esecuzione per verificare che hbbr sia in esecuzione usando la tua coppia di chiavi.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.ja.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.ja.md
@@ -35,7 +35,44 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 既知の問題: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> 秘密鍵ペア`id_ed25519`と`id_ed25519.pub`が必要です。
+> `hbbr`の環境変数`KEY`に`id_ed25519.pub`の公開鍵を設定するか、`id_ed25519`と`id_ed25519.pub`をリレーサーバーにコピーします。
+
+### Docker Compose
+
+追加のリレーサーバーに必要なのは`hbbr`だけです。`hbbs`と`depends_on`は必要ありません。次のいずれかの鍵設定方法を選択します。
+
+- `environment`セクションを残し、次の例のように`KEY`に`id_ed25519.pub`の内容を設定します。
+- `environment`セクション全体を削除し、`id_ed25519`と`id_ed25519.pub`を`./data`に配置します。
+
+次の内容で`compose.yml`ファイルを作成します。
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### 環境変数で鍵を設定する
+
+`KEY`に`id_ed25519.pub`の内容を設定します。
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### 鍵ファイルを使用する
+
+以下のDockerの例では、鍵ファイルを使用する方法を示します。
 
 1 - dockerがすでにインストールされている場合、SSH経由でサーバーに接続し、hbbr用のボリュームを作成します。
 
@@ -57,8 +94,18 @@ hbbrボリュームは`/var/lib/docker/volumes/hbbr/_data`に配置される必�
 3 - 以前に作成したボリュームを使用してhbbrコンテナをデプロイします。このボリュームには、プライベートリレーサーバーを実行するために必要な秘密鍵ペアが含まれています。
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+`rustdesk/rustdesk-server`イメージでは、引き続き`-k <KEY>`を使用できます。マウントした鍵ファイルを使用するには、`-k _`を指定して実行します。
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+ここで`_`は鍵そのものではなく、特別な値です。`hbbr`に`id_ed25519`を読み込むか生成させ、そこから公開鍵を取得してリレー要求の検証に使用させます。RustDesk Server Pro 1.8.6より前のバージョンでも、`id_ed25519`を読み込むために`-k _`を使用できました。
+
+RustDesk Server Pro 1.8.6以降、`hbbr`の`-k`オプションは非推奨となり、無視されます。`KEY`が設定されていない場合、`hbbr`は`id_ed25519`から公開鍵を取得し、秘密鍵ファイルが存在しない場合は`id_ed25519.pub`から読み取ります。どちらのファイルも存在しない場合、`hbbr`は公開リレーモードで動作します。
 
 4 - 実行ログを確認して、hbbrが鍵ペアを使用して実行されていることを確認します。
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.ko.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.ko.md
@@ -14,7 +14,7 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 ## 릴레이 설정 체크리스트
 
 1. 대상 지역에 추가 `hbbr` 릴레이 서버를 배포합니다.
-2. `id_ed25519` 및 `id_ed25519.pub` 키 쌍을 해당 릴레이 서버로 복사합니다.
+2. `hbbr`의 `KEY` 환경 변수를 `id_ed25519.pub`의 공개 키로 설정하거나 `id_ed25519` 및 `id_ed25519.pub`를 릴레이 서버로 복사합니다.
 3. TCP 포트 `21117`와 `21119`를 열어줍니다.
 4. RustDesk Pro 웹 콘솔에 새로운 릴레이 호스트명 또는 IP 주소를 추가합니다.
 5. `hbbs`에 MaxMind GeoLite2 City 데이터베이스를 설치합니다.
@@ -36,7 +36,44 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 알려진 문제: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> 개인 키 쌍 `id_ed25519`와 `id_ed25519.pub`가 필요합니다.
+> `hbbr`의 `KEY` 환경 변수를 `id_ed25519.pub`의 공개 키로 설정하거나 `id_ed25519` 및 `id_ed25519.pub`를 릴레이 서버로 복사합니다.
+
+### Docker Compose
+
+추가 릴레이 서버에는 `hbbr`만 필요하며 `hbbs`와 `depends_on`은 필요하지 않습니다. 다음 키 구성 방법 중 하나를 선택합니다.
+
+- `environment` 섹션을 유지하고 아래와 같이 `KEY`를 `id_ed25519.pub`의 내용으로 설정합니다.
+- `environment` 섹션 전체를 제거하고 `id_ed25519`와 `id_ed25519.pub`를 `./data`에 넣습니다.
+
+다음 내용으로 `compose.yml` 파일을 만듭니다.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### 환경 변수로 키 설정
+
+`KEY`를 `id_ed25519.pub`의 내용으로 설정합니다.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### 키 파일 사용
+
+아래 Docker 예제에서는 키 파일 방식을 사용합니다.
 
 1 - 이미 Docker가 설치되어 있다면 SSH를 통해 서버에 연결하고 hbbr용 볼륨을 생성하세요.
 
@@ -58,8 +95,18 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 3 - 이전에 생성한 볼륨을 사용하여 hbbr 컨테이너를 배포하십시오. 이 볼륨에는 개인 릴레이 서버를 실행하는 데 필요한 개인 키 쌍이 있습니다.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+`rustdesk/rustdesk-server` 이미지는 여전히 `-k <KEY>`를 지원합니다. 마운트된 키 파일을 사용하려면 `-k _`를 지정하여 실행합니다.
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+여기서 `_`는 키 자체가 아니라 특수 값입니다. 이 값은 `hbbr`가 `id_ed25519`를 불러오거나 생성하고, 여기에서 공개 키를 얻어 릴레이 요청을 검증하도록 합니다. RustDesk Server Pro 1.8.6 이전 버전에서도 `id_ed25519`를 불러오기 위해 `-k _`를 사용할 수 있었습니다.
+
+RustDesk Server Pro 1.8.6부터 `hbbr`의 `-k` 옵션은 더 이상 사용되지 않으며 무시됩니다. `KEY`가 설정되지 않은 경우 `hbbr`는 `id_ed25519`에서 공개 키를 가져오며, 개인 키 파일이 없으면 `id_ed25519.pub`에서 읽습니다. 두 파일이 모두 없으면 `hbbr`는 공개 릴레이 모드로 실행됩니다.
 
 4 - 실행 로그를 확인하여 키 쌍을 사용해 hbbr가 실행 중인지 확인하십시오.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.pl.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.pl.md
@@ -39,7 +39,44 @@ Możesz uruchomić wiele serwerów relay na całym świecie i wykorzystywać aut
 Znany problem: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Będziesz potrzebować pary kluczy prywatnych `id_ed25519` i `id_ed25519.pub`.
+> Ustaw zmienną środowiskową `KEY` procesu `hbbr` na klucz publiczny z pliku `id_ed25519.pub` albo skopiuj pliki `id_ed25519` i `id_ed25519.pub` na serwer relay.
+
+### Docker Compose
+
+Dodatkowy serwer relay wymaga tylko procesu `hbbr`; `hbbs` i `depends_on` nie są potrzebne. Wybierz jedną z poniższych metod konfiguracji klucza:
+
+- Zachowaj sekcję `environment` i ustaw `KEY` na zawartość pliku `id_ed25519.pub`, jak pokazano poniżej.
+- Usuń całą sekcję `environment` i umieść pliki `id_ed25519` oraz `id_ed25519.pub` w katalogu `./data`.
+
+Utwórz plik `compose.yml` z następującą zawartością.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Ustawianie klucza za pomocą zmiennej środowiskowej
+
+Ustaw `KEY` na zawartość pliku `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Używanie plików kluczy
+
+Poniższy przykład Dockera korzysta z metody z plikami kluczy.
 
 1 - Jeśli docker jest już zainstalowany, połącz się z serwerem przez SSH i utwórz wolumin dla hbbr.
 
@@ -61,8 +98,18 @@ Polecenie to `scp <ścieżka/nazwa pliku> nazwa użytkownika@serwer:</ścieżka 
 3 - Wdróż kontener hbbr przy użyciu utworzonego wcześniej woluminu. Wolumin ten zawiera parę kluczy prywatnych niezbędnych do uruchomienia prywatnego serwera przekaźnikowego.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+Obraz `rustdesk/rustdesk-server` nadal akceptuje `-k <KEY>`. Aby użyć zamontowanego pliku klucza, uruchom go z opcją `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+W tym przypadku `_` jest wartością specjalną, a nie samym kluczem. Nakazuje ona procesowi `hbbr` wczytać lub wygenerować `id_ed25519`, wyprowadzić z niego klucz publiczny i użyć tego klucza do sprawdzania żądań relay. Wersje RustDesk Server Pro starsze niż 1.8.6 również akceptowały `-k _` w celu wczytania `id_ed25519`.
+
+Od wersji RustDesk Server Pro 1.8.6 opcja `-k` programu `hbbr` jest przestarzała i ignorowana. Jeśli zmienna `KEY` nie jest ustawiona, `hbbr` pobiera klucz publiczny z pliku `id_ed25519` lub odczytuje go z pliku `id_ed25519.pub`, gdy plik klucza prywatnego nie istnieje. Jeśli nie istnieje żaden z tych plików, `hbbr` działa w trybie publicznego serwera relay.
 
 4 - Sprawdź logi działania, aby upewnić się, że hbbr działa przy użyciu twojej pary kluczy.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.pt.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.pt.md
@@ -35,7 +35,44 @@ Você pode ter vários servidores de retransmissão rodando pelo mundo e aprovei
 Problema conhecido: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Você precisará do par de chaves privadas `id_ed25519` e `id_ed25519.pub`.
+> Defina a variável de ambiente `KEY` do `hbbr` com a chave pública contida em `id_ed25519.pub` ou copie `id_ed25519` e `id_ed25519.pub` para o servidor de retransmissão.
+
+### Docker Compose
+
+Um servidor de retransmissão adicional precisa apenas do `hbbr`; `hbbs` e `depends_on` não são necessários. Escolha um dos seguintes métodos de configuração da chave:
+
+- Mantenha a seção `environment` e defina `KEY` com o conteúdo de `id_ed25519.pub`, conforme mostrado abaixo.
+- Remova toda a seção `environment` e coloque `id_ed25519` e `id_ed25519.pub` em `./data`.
+
+Crie um arquivo `compose.yml` com o seguinte conteúdo.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Definir a chave com uma variável de ambiente
+
+Defina `KEY` com o conteúdo de `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Usar arquivos de chave
+
+O exemplo do Docker abaixo usa o método de arquivos de chave.
 
 1 - Se o docker já estiver instalado, conecte-se ao seu servidor via SSH e crie um volume para hbbr.
 
@@ -57,8 +94,18 @@ A sintaxe do comando é `scp <caminho/nome_arquivo> usuario@servidor:</caminho/d
 3 - Implante o contêiner hbbr usando o volume criado anteriormente. Este volume tem o par de chaves privadas necessário para executar seu servidor de retransmissão privado.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+A imagem `rustdesk/rustdesk-server` ainda aceita `-k <KEY>`. Para usar o arquivo de chave montado, execute-a com `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Aqui, `_` é um valor especial, não a chave em si. Ele instrui o `hbbr` a carregar ou gerar `id_ed25519`, obter sua chave pública e usá-la para validar solicitações de retransmissão. As versões do RustDesk Server Pro anteriores à 1.8.6 também aceitavam `-k _` para carregar `id_ed25519`.
+
+A partir do RustDesk Server Pro 1.8.6, a opção `-k` do `hbbr` está obsoleta e é ignorada. Se `KEY` não estiver definida, o `hbbr` obtém a chave pública de `id_ed25519` ou a lê de `id_ed25519.pub` se o arquivo da chave privada não existir. Se nenhum dos arquivos existir, o `hbbr` será executado no modo de retransmissão pública.
 
 4 - Verifique os logs de execução para verificar se o hbbr está rodando usando seu par de chaves.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.ro.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.ro.md
@@ -35,7 +35,44 @@ Puteți rula mai multe servere relay distribuite geografic și folosi GeoLocatio
 Problemă cunoscută: https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> Veți avea nevoie de perechea de chei private `id_ed25519` și `id_ed25519.pub`.
+> Setați variabila de mediu `KEY` a procesului `hbbr` la cheia publică din `id_ed25519.pub` sau copiați `id_ed25519` și `id_ed25519.pub` pe serverul relay.
+
+### Docker Compose
+
+Un server relay suplimentar are nevoie doar de `hbbr`; `hbbs` și `depends_on` nu sunt necesare. Alegeți una dintre următoarele metode de configurare a cheii:
+
+- Păstrați secțiunea `environment` și setați `KEY` la conținutul fișierului `id_ed25519.pub`, după cum se arată mai jos.
+- Eliminați întreaga secțiune `environment` și plasați `id_ed25519` și `id_ed25519.pub` în `./data`.
+
+Creați un fișier `compose.yml` cu următorul conținut.
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### Setarea cheii printr-o variabilă de mediu
+
+Setați `KEY` la conținutul fișierului `id_ed25519.pub`.
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### Utilizarea fișierelor cu chei
+
+Exemplul Docker de mai jos utilizează metoda bazată pe fișierele cu chei.
 
 1 - Dacă Docker este deja instalat, conectați‑vă la server prin SSH și creați un volume pentru `hbbr`.
 
@@ -57,8 +94,18 @@ Sintaxa comenzii este `scp <path/filename> username@server:</destination/path>`.
 3 - Desfășurați containerul `hbbr` folosind volumul creat anterior. Acest volume conține perechea de chei private necesară pentru a rula serverul relay privat.
 
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+Imaginea `rustdesk/rustdesk-server` acceptă în continuare `-k <KEY>`. Pentru a utiliza fișierul cheii montat, rulați-o cu `-k _`:
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+Aici, `_` este o valoare specială, nu cheia propriu-zisă. Aceasta indică procesului `hbbr` să încarce sau să genereze `id_ed25519`, să obțină cheia publică din acesta și să o utilizeze pentru validarea solicitărilor relay. Versiunile RustDesk Server Pro anterioare versiunii 1.8.6 acceptau, de asemenea, `-k _` pentru a încărca `id_ed25519`.
+
+Începând cu RustDesk Server Pro 1.8.6, opțiunea `-k` a procesului `hbbr` este perimată și ignorată. Dacă `KEY` nu este setată, `hbbr` obține cheia publică din `id_ed25519` sau o citește din `id_ed25519.pub` dacă fișierul cheii private nu există. Dacă niciunul dintre fișiere nu există, `hbbr` rulează în modul relay public.
 
 4 - Verificați jurnalele pentru a confirma că `hbbr` rulează folosind perechea de chei.
 

--- a/content/self-host/rustdesk-server-pro/relay/_index.zh-cn.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.zh-cn.md
@@ -35,7 +35,44 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 已知问题：https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> 您需要私钥对`id_ed25519`和`id_ed25519.pub`。
+> 将`hbbr`的`KEY`环境变量设置为`id_ed25519.pub`中的公钥，或者将`id_ed25519`和`id_ed25519.pub`复制到中继服务器。
+
+### Docker Compose
+
+额外的中继服务器只需要运行`hbbr`，不需要`hbbs`和`depends_on`。请选择以下一种密钥配置方式：
+
+- 保留`environment`部分，并按以下示例将`KEY`设置为`id_ed25519.pub`的内容。
+- 删除整个`environment`部分，并将`id_ed25519`和`id_ed25519.pub`放入`./data`。
+
+创建一个包含以下内容的`compose.yml`文件。
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### 使用环境变量设置密钥
+
+将`KEY`设置为`id_ed25519.pub`的内容。
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### 使用密钥文件
+
+下面的Docker示例使用密钥文件方式。
 
 # 安装步骤
 
@@ -56,8 +93,18 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 
 3. 使用先前创建的卷部署hbbr容器。该卷包含运行私有中继服务器所需的私钥对。
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+`rustdesk/rustdesk-server`镜像仍支持`-k <KEY>`。要使用挂载的密钥文件，请通过`-k _`运行：
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+这里的`_`是一个特殊值，并不是密钥本身。它会让`hbbr`加载或生成`id_ed25519`，从中获取公钥，并使用该公钥验证中继请求。RustDesk Server Pro 1.8.6之前的版本也支持通过`-k _`加载`id_ed25519`。
+
+从RustDesk Server Pro 1.8.6开始，`hbbr`的`-k`选项已弃用且会被忽略。如果未设置`KEY`，`hbbr`会从`id_ed25519`中获取公钥；如果私钥文件不存在，则从`id_ed25519.pub`中读取。如果两个文件都不存在，`hbbr`将以公开中继模式运行。
 
 4. 检查运行日志以验证hbbr正在使用您的密钥对运行：
 ```

--- a/content/self-host/rustdesk-server-pro/relay/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-pro/relay/_index.zh-tw.md
@@ -35,7 +35,44 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 已知問題：https://github.com/rustdesk/rustdesk/discussions/7934
 {{% /notice %}}
 
-> 您需要私鑰對`id_ed25519`和`id_ed25519.pub`。
+> 將`hbbr`的`KEY`環境變數設定為`id_ed25519.pub`中的公開金鑰，或者將`id_ed25519`和`id_ed25519.pub`複製到中繼伺服器。
+
+### Docker Compose
+
+額外的中繼伺服器只需要執行`hbbr`，不需要`hbbs`和`depends_on`。請選擇以下一種金鑰設定方式：
+
+- 保留`environment`部分，並依照以下範例將`KEY`設定為`id_ed25519.pub`的內容。
+- 刪除整個`environment`部分，並將`id_ed25519`和`id_ed25519.pub`放入`./data`。
+
+建立一個包含以下內容的`compose.yml`檔案。
+
+```yaml
+services:
+  hbbr:
+    container_name: hbbr
+    image: docker.io/rustdesk/rustdesk-server-pro:latest
+    environment:
+      KEY: "<PUBLIC_KEY>"
+    command: hbbr
+    volumes:
+      - ./data:/root
+    network_mode: "host"
+    restart: unless-stopped
+```
+
+### Docker
+
+#### 使用環境變數設定金鑰
+
+將`KEY`設定為`id_ed25519.pub`的內容。
+
+```bash
+# sudo docker run --name hbbr -e KEY="<PUBLIC_KEY>" -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+#### 使用金鑰檔案
+
+下面的Docker範例使用金鑰檔案方式。
 
 # 安裝步驟
 
@@ -56,8 +93,18 @@ keywords: ["rustdesk relay server", "rustdesk hbbr", "rustdesk geolocation relay
 
 3 - 使用先前創建的卷部署hbbr容器。該卷包含運行私有中繼伺服器所需的私鑰對。
 ```
+# sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server-pro hbbr
+```
+
+`rustdesk/rustdesk-server`映像仍支援`-k <KEY>`。若要使用掛載的金鑰檔案，請透過`-k _`執行：
+
+```bash
 # sudo docker run --name hbbr -v hbbr:/root -td --net=host rustdesk/rustdesk-server hbbr -k _
 ```
+
+這裡的`_`是一個特殊值，並不是金鑰本身。它會讓`hbbr`載入或產生`id_ed25519`，從中取得公開金鑰，並使用該公開金鑰驗證中繼請求。RustDesk Server Pro 1.8.6之前的版本也支援透過`-k _`載入`id_ed25519`。
+
+從RustDesk Server Pro 1.8.6開始，`hbbr`的`-k`選項已棄用且會被忽略。如果未設定`KEY`，`hbbr`會從`id_ed25519`中取得公開金鑰；如果私鑰檔案不存在，則從`id_ed25519.pub`中讀取。如果兩個檔案都不存在，`hbbr`將以公開中繼模式執行。
 
 4 - 檢查運行日誌以驗證hbbr正在使用您的密鑰對運行：
 ```


### PR DESCRIPTION
  - add relay-only Docker Compose configuration
  - document KEY and key-file setup methods
  - clarify legacy -k _ behavior and Pro 1.8.6 changes

Tested
* docker compose KEY env
* docker compose key file
* docker run KEY env, rustdesk server pro
* docker run key file, rustdesk server pro