### PR TITLE
docs: document admin and control role API scripts

### DIFF
--- a/content/self-host/rustdesk-server-pro/console/_index.de.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.de.md
@@ -114,7 +114,7 @@ Um eine Strategie einem Gerät zuzuweisen, bewege die Maus auf die rechte Seite 
 ## API-Token
 
 Zuerst musst du zu **Settings → Tokens → Create** gehen und ein Token mit den erforderlichen Berechtigungen erstellen:  
-**Device, Audit Log, User, Group, Strategy, Address Book**.  
+**Device, Audit Log, User, Group, Strategy, Address Book, Admin Role, Control Role**.
 
 Nach der Erstellung kannst du diese Tokens über die **Befehlszeile (Command Line)** oder das **Python CLI** verwenden, um Aktionen mit den entsprechenden Berechtigungen auszuführen.
 
@@ -281,6 +281,107 @@ oder
 **Berechtigungsanforderungen:**
 - `view/add/update/delete/add-users` Befehle benötigen **Benutzergruppen-Berechtigung**
 - `view-users` Befehl benötigt **Benutzerberechtigung**
+
+---
+
+#### Verwaltung von Admin-Rollen (`admin-roles.py`)
+
+Das Token muss zu einem vollständigen Administrator gehören und für **Admin Role** Lese- oder Lese-/Schreibberechtigung besitzen. Befehle zum Auflösen von Benutzernamen oder Auflisten von Rollenmitgliedern benötigen außerdem Leseberechtigung für **User**.
+
+**Rollen anzeigen:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <rollenname>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <rollen-guid>
+```
+
+**Rolle erstellen:**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Nur-Lese-Support"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+Der Rollentyp kann nach der Erstellung nicht geändert werden. `--permissions` akzeptiert kommagetrennte Berechtigungsnamen, Dezimal-IDs oder IDs mit dem Präfix `0x`; die Formate können gemischt werden. Beispielsweise entspricht `users.view,513,0x0203` dem Wert `257,513,515`. Der Server lehnt Berechtigungen ab, die für den gewählten Rollentyp ungültig sind.
+
+Der Befehl `view` wandelt bekannte Berechtigungs-IDs zurück in die Namen der folgenden Tabelle. Eine dem Skript unbekannte ID bleibt als Zahl erhalten, damit von einem neueren Server hinzugefügte Berechtigungen nicht verborgen werden.
+
+| Bereich | Berechtigungen | Gültige Rollentypen |
+| --- | --- | --- |
+| Benutzer | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| Benutzer | `users.change_group` (`268`) | `global` |
+| Geräte | `devices.view` (`513`) | `global`, `group` |
+| Geräte | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| Geräte | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| Benutzergruppen | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| Gerätegruppen | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| Prüfprotokolle | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| Strategien | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| Benutzerdefinierte Clients | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| Steuerungsrollen | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**Rolle aktualisieren oder löschen:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "neue Notiz"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Mit einem leeren Wert für `--note`, `--permissions`, `--user-groups` oder `--device-groups` wird das jeweilige Feld geleert, zum Beispiel mit `--permissions ""`.
+
+**Rollenmitglieder verwalten:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Rollen und Benutzer können auch per GUID angegeben werden. In `--users` dürfen Benutzernamen und GUIDs gemischt werden.
+
+---
+
+#### Verwaltung von Steuerungsrollen (`control-roles.py`)
+
+Das Token benötigt für **Control Role** Lese- oder Lese-/Schreibberechtigung. Befehle zum Auflösen von Benutzernamen oder Auflisten von Rollenmitgliedern benötigen außerdem Leseberechtigung für **User**.
+
+**Rollen anzeigen:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <rollenname>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <rollen-guid>
+```
+
+**Rolle erstellen, aktualisieren, löschen, aktivieren oder deaktivieren:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Eingeschränkter Zugriff"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "neue Notiz"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+Neue Rollen, die mit diesem Skript erstellt werden, enthalten keine Steuerungsberechtigungen. Konfigurieren Sie diese in der Webkonsole, bevor Sie Benutzer zuweisen. Steuerungsberechtigungen werden von diesem Skript weder verwaltet noch angezeigt.
+
+**Rollenmitglieder verwalten:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Rollen und Benutzer können auch per GUID angegeben werden. `remove-users` entfernt die aktuelle Steuerungsrolle jedes Benutzers und verwendet daher weder `--name` noch `--guid`. Bei der reservierten Rolle `Default` zeigt `view-users` nur explizite Zuweisungen; Benutzer ohne zugewiesene Steuerungsrolle erben ebenfalls `Default`. Die Rolle `Not Logged` kann Benutzern nicht zugewiesen werden. Reservierte Rollen können nicht umbenannt, mit einer Notiz versehen oder gelöscht werden.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.en.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.en.md
@@ -129,7 +129,7 @@ To assign a strategy to a device, hover over the right side of the **Strategy** 
 
 ## API Token
 
-You must first go to **Settings → Tokens → Create** and create a token with the required permissions: **Device, Audit Log, User, Group, Strategy, Address Book**.  
+You must first go to **Settings → Tokens → Create** and create a token with the required permissions: **Device, Audit Log, User, Group, Strategy, Address Book, Admin Role, Control Role**.
 
 Once created, you can use these tokens via **command line** or **Python CLI** to perform actions with the corresponding permissions.
 
@@ -287,6 +287,112 @@ The command line on Windows does not have output by default. To get output, plea
 **Permission requirements:**
 - `view/add/update/delete/add-users` commands require **User Group Permission**
 - `view-users` command requires **User Permission**
+
+---
+
+#### Admin Roles Management (`admin-roles.py`)
+
+The token must belong to a full administrator and have **Admin Role** read or read/write permission. Commands that resolve user names or list role members also require **User** read permission.
+
+**View roles:**
+
+```bash
+# List roles, optionally filtered by exact name or type
+./admin-roles.py --url <url> --token <token> view [--name <role_name>] [--type global|individual|group]
+
+# View one role by GUID
+./admin-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Create a role:**
+
+```bash
+# Global role
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Read-only support"
+
+# Group-scoped role
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+The role type cannot be changed after creation. `--permissions` accepts comma-separated permission names, decimal IDs, or `0x`-prefixed IDs, and the formats can be mixed. For example, `users.view,513,0x0203` is equivalent to `257,513,515`. The server rejects permissions that are not valid for the selected role type.
+
+The `view` command converts known permission IDs back to the names below. An ID unknown to the script is preserved as a number so permissions added by a newer server are not hidden.
+
+| Area | Permissions | Valid role types |
+| --- | --- | --- |
+| Users | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | global, group |
+| Users | `users.change_group` (`268`) | global |
+| Devices | `devices.view` (`513`) | global, group |
+| Devices | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | global, individual, group |
+| Devices | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | global |
+| User groups | `user_groups.view` (`769`); `user_groups.edit` (`770`) | global |
+| Device groups | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | global |
+| Audits | `audits.view` (`1281`); `audits.edit` (`1282`) | global, individual |
+| Strategies | `strategies.view` (`1537`); `strategies.edit` (`1538`) | global |
+| Custom clients | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | global |
+| Control roles | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | global |
+
+**Update or delete a role:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "new note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Pass an empty value to clear `--note`, `--permissions`, `--user-groups`, or `--device-groups`, for example `--permissions ""`.
+
+**Manage role members:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Role targets and users can also be supplied by GUID. User names and GUIDs can be mixed in `--users`.
+
+---
+
+#### Control Roles Management (`control-roles.py`)
+
+The token needs **Control Role** read or read/write permission. Commands that resolve user names or list role members also require **User** read permission.
+
+**View roles:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <role_name>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Create, update, delete, enable, or disable a role:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Restricted access"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "new note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+New roles created by this script do not include control permissions. Configure them in the web console before assigning users. Control-permission definitions are not managed or displayed by this script.
+
+**Manage role members:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Role targets and users can also be supplied by GUID. `remove-users` clears each user's current control role, so it does not take `--name` or `--guid`. For the reserved `Default` role, `view-users` lists explicit assignments only; users without a control-role assignment also inherit `Default`. The reserved `Not Logged` role cannot be assigned to users, and reserved roles cannot be renamed, given a note, or deleted.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.es.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.es.md
@@ -117,7 +117,7 @@ Para asignar una estrategia a un dispositivo, pase el cursor sobre el lado derec
 
 ## Token de API
 
-Primero debe ir a **Configuración → Tokens → Crear** y crear un token con los permisos requeridos: **Dispositivo, Registro de Auditoría, Usuario, Grupo, Estrategia, Libreta de Direcciones**.
+Primero debe ir a **Configuración → Tokens → Crear** y crear un token con los permisos requeridos: **Dispositivo, Registro de Auditoría, Usuario, Grupo, Estrategia, Libreta de Direcciones, Rol de Administrador, Rol de Control**.
 
 Una vez creado, puede usar estos tokens a través de **línea de comandos** o **Python CLI** para realizar acciones con los permisos correspondientes.
 
@@ -280,6 +280,107 @@ ver [aquí](https://github.com/rustdesk/rustdesk/discussions/6377#discussioncomm
 **Requisitos de permisos:**
 - Los comandos `view/add/update/delete/add-users` requieren **Permiso de Grupo de Usuarios**
 - El comando `view-users` requiere **Permiso de Usuario**
+
+---
+
+#### Gestión de roles de administrador (`admin-roles.py`)
+
+El token debe pertenecer a un administrador completo y tener permiso de lectura o de lectura y escritura para **Admin Role**. Los comandos que resuelven nombres de usuario o enumeran miembros del rol también requieren permiso de lectura para **User**.
+
+**Ver roles:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <nombre_rol>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <guid_rol>
+```
+
+**Crear un rol:**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Soporte de solo lectura"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+El tipo de rol no puede cambiarse después de crearlo. `--permissions` acepta nombres de permisos separados por comas, IDs decimales o IDs con prefijo `0x`, y permite mezclar los formatos. Por ejemplo, `users.view,513,0x0203` equivale a `257,513,515`. El servidor rechaza los permisos que no sean válidos para el tipo de rol seleccionado.
+
+El comando `view` convierte los IDs de permisos conocidos en los nombres de la tabla siguiente. Un ID desconocido para el script se conserva como número para no ocultar permisos añadidos por una versión más reciente del servidor.
+
+| Área | Permisos | Tipos de rol válidos |
+| --- | --- | --- |
+| Usuarios | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| Usuarios | `users.change_group` (`268`) | `global` |
+| Dispositivos | `devices.view` (`513`) | `global`, `group` |
+| Dispositivos | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| Dispositivos | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| Grupos de usuarios | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| Grupos de dispositivos | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| Registros de auditoría | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| Estrategias | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| Clientes personalizados | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| Roles de control | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**Actualizar o eliminar un rol:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "nueva nota"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Pase un valor vacío a `--note`, `--permissions`, `--user-groups` o `--device-groups` para borrar el campo, por ejemplo `--permissions ""`.
+
+**Gestionar miembros del rol:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Los roles y usuarios también pueden indicarse mediante GUID. En `--users` pueden mezclarse nombres de usuario y GUID.
+
+---
+
+#### Gestión de roles de control (`control-roles.py`)
+
+El token necesita permiso de lectura o de lectura y escritura para **Control Role**. Los comandos que resuelven nombres de usuario o enumeran miembros del rol también requieren permiso de lectura para **User**.
+
+**Ver roles:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <nombre_rol>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <guid_rol>
+```
+
+**Crear, actualizar, eliminar, habilitar o deshabilitar un rol:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Acceso restringido"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "nueva nota"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+Los roles creados con este script no incluyen permisos de control. Configúrelos en la consola web antes de asignar usuarios. Este script no administra ni muestra las definiciones de permisos de control.
+
+**Gestionar miembros del rol:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Los roles y usuarios también pueden indicarse mediante GUID. `remove-users` borra el rol de control actual de cada usuario, por lo que no acepta `--name` ni `--guid`. Para el rol reservado `Default`, `view-users` solo muestra asignaciones explícitas; los usuarios sin rol de control asignado también heredan `Default`. El rol `Not Logged` no puede asignarse a usuarios, y los roles reservados no pueden renombrarse, recibir una nota ni eliminarse.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.fr.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.fr.md
@@ -117,7 +117,7 @@ Pour attribuer une stratégie à un périphérique, survolez le côté droit de 
 
 ## Jeton API
 
-Vous devez d’abord aller dans **Paramètres → Jetons → Créer** et créer un jeton avec les permissions requises : **Périphérique, Journal d’Audit, Utilisateur, Groupe, Stratégie, Carnet d’Adresses**.
+Vous devez d’abord aller dans **Paramètres → Jetons → Créer** et créer un jeton avec les permissions requises : **Périphérique, Journal d’Audit, Utilisateur, Groupe, Stratégie, Carnet d’Adresses, Rôle Administrateur, Rôle de Contrôle**.
 
 Une fois créé, vous pouvez utiliser ces jetons via **ligne de commande** ou **Python CLI** pour effectuer des actions avec les permissions correspondantes.
 
@@ -280,6 +280,107 @@ voir [ici](https://github.com/rustdesk/rustdesk/discussions/6377#discussioncomme
 **Exigences de permissions :**
 - Les commandes `view/add/update/delete/add-users` nécessitent **Permission de Groupe d'Utilisateurs**
 - La commande `view-users` nécessite **Permission d'Utilisateur**
+
+---
+
+#### Gestion des rôles administrateur (`admin-roles.py`)
+
+Le jeton doit appartenir à un administrateur complet et disposer d’un accès en lecture ou en lecture-écriture pour **Admin Role**. Les commandes qui résolvent les noms d’utilisateur ou répertorient les membres d’un rôle nécessitent également un accès en lecture pour **User**.
+
+**Afficher les rôles :**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <nom_role>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <guid_role>
+```
+
+**Créer un rôle :**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Support en lecture seule"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+Le type d’un rôle ne peut plus être modifié après sa création. `--permissions` accepte des noms de permissions séparés par des virgules, des ID décimaux ou des ID préfixés par `0x`, et ces formats peuvent être mélangés. Par exemple, `users.view,513,0x0203` équivaut à `257,513,515`. Le serveur rejette les permissions qui ne sont pas valides pour le type de rôle choisi.
+
+La commande `view` reconvertit les ID connus en noms figurant dans le tableau suivant. Un ID inconnu du script reste affiché sous forme numérique afin de ne pas masquer une permission ajoutée par un serveur plus récent.
+
+| Domaine | Permissions | Types de rôle valides |
+| --- | --- | --- |
+| Utilisateurs | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| Utilisateurs | `users.change_group` (`268`) | `global` |
+| Périphériques | `devices.view` (`513`) | `global`, `group` |
+| Périphériques | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| Périphériques | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| Groupes d’utilisateurs | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| Groupes de périphériques | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| Journaux d’audit | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| Stratégies | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| Clients personnalisés | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| Rôles de contrôle | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**Mettre à jour ou supprimer un rôle :**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "nouvelle note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Passez une valeur vide à `--note`, `--permissions`, `--user-groups` ou `--device-groups` pour effacer le champ, par exemple `--permissions ""`.
+
+**Gérer les membres du rôle :**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Les rôles et les utilisateurs peuvent également être indiqués par GUID. `--users` accepte un mélange de noms d’utilisateur et de GUID.
+
+---
+
+#### Gestion des rôles de contrôle (`control-roles.py`)
+
+Le jeton doit disposer d’un accès en lecture ou en lecture-écriture pour **Control Role**. Les commandes qui résolvent les noms d’utilisateur ou répertorient les membres d’un rôle nécessitent également un accès en lecture pour **User**.
+
+**Afficher les rôles :**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <nom_role>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <guid_role>
+```
+
+**Créer, mettre à jour, supprimer, activer ou désactiver un rôle :**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Accès restreint"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "nouvelle note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+Les nouveaux rôles créés avec ce script ne contiennent aucune permission de contrôle. Configurez-les dans la console web avant d’y affecter des utilisateurs. Ce script ne gère et n’affiche pas les définitions des permissions de contrôle.
+
+**Gérer les membres du rôle :**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Les rôles et les utilisateurs peuvent également être indiqués par GUID. `remove-users` efface le rôle de contrôle actuel de chaque utilisateur et n’accepte donc ni `--name` ni `--guid`. Pour le rôle réservé `Default`, `view-users` ne répertorie que les affectations explicites ; les utilisateurs sans rôle de contrôle affecté héritent également de `Default`. Le rôle `Not Logged` ne peut pas être affecté à des utilisateurs, et les rôles réservés ne peuvent pas être renommés, recevoir une note ou être supprimés.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.it.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.it.md
@@ -117,7 +117,7 @@ Per assegnare una strategia a un dispositivo, passare il mouse sul lato destro d
 
 ## Token API
 
-È necessario prima andare su **Impostazioni → Token → Crea** e creare un token con le autorizzazioni richieste: **Dispositivo, Registro Audit, Utente, Gruppo, Strategia, Rubrica**.
+È necessario prima andare su **Impostazioni → Token → Crea** e creare un token con le autorizzazioni richieste: **Dispositivo, Registro Audit, Utente, Gruppo, Strategia, Rubrica, Ruolo Amministratore, Ruolo di Controllo**.
 
 Una volta creato, è possibile utilizzare questi token tramite **linea di comando** o **Python CLI** per eseguire azioni con le autorizzazioni corrispondenti.
 
@@ -280,6 +280,112 @@ vedi [qui](https://github.com/rustdesk/rustdesk/discussions/6377#discussioncomme
 **Requisiti di permessi:**
 - I comandi `view/add/update/delete/add-users` richiedono **Permesso Gruppo Utenti**
 - Il comando `view-users` richiede **Permesso Utente**
+
+---
+
+#### Gestione dei ruoli amministratore (`admin-roles.py`)
+
+Il token deve appartenere a un amministratore completo e disporre del permesso **Ruolo Amministratore** in lettura o lettura/scrittura. I comandi che risolvono i nomi utente o elencano i membri del ruolo richiedono anche il permesso **Utente** in lettura.
+
+**Visualizza i ruoli:**
+
+```bash
+# Elenca i ruoli, filtrandoli facoltativamente per nome esatto o tipo
+./admin-roles.py --url <url> --token <token> view [--name <role_name>] [--type global|individual|group]
+
+# Visualizza un ruolo tramite GUID
+./admin-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Crea un ruolo:**
+
+```bash
+# Ruolo globale
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Read-only support"
+
+# Ruolo con ambito di gruppo
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+Il tipo di ruolo non può essere modificato dopo la creazione. `--permissions` accetta nomi di permessi, ID decimali o ID con prefisso `0x`, separati da virgole; i formati possono essere combinati. Ad esempio, `users.view,513,0x0203` equivale a `257,513,515`. Il server rifiuta i permessi non validi per il tipo di ruolo selezionato.
+
+Il comando `view` riconverte gli ID dei permessi conosciuti nei nomi riportati di seguito. Un ID sconosciuto allo script viene mantenuto come numero, affinché i permessi aggiunti da una versione più recente del server non vengano nascosti.
+
+| Area | Permessi | Tipi di ruolo validi |
+| --- | --- | --- |
+| Utenti | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | global, group |
+| Utenti | `users.change_group` (`268`) | global |
+| Dispositivi | `devices.view` (`513`) | global, group |
+| Dispositivi | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | global, individual, group |
+| Dispositivi | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | global |
+| Gruppi di utenti | `user_groups.view` (`769`); `user_groups.edit` (`770`) | global |
+| Gruppi di dispositivi | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | global |
+| Audit | `audits.view` (`1281`); `audits.edit` (`1282`) | global, individual |
+| Strategie | `strategies.view` (`1537`); `strategies.edit` (`1538`) | global |
+| Client personalizzati | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | global |
+| Ruoli di controllo | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | global |
+
+**Aggiorna o elimina un ruolo:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "new note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Passare un valore vuoto per cancellare `--note`, `--permissions`, `--user-groups` o `--device-groups`, ad esempio `--permissions ""`.
+
+**Gestisci i membri del ruolo:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+I ruoli e gli utenti di destinazione possono essere indicati anche tramite GUID. In `--users` è possibile combinare nomi utente e GUID.
+
+---
+
+#### Gestione dei ruoli di controllo (`control-roles.py`)
+
+Il token deve disporre del permesso **Ruolo di Controllo** in lettura o lettura/scrittura. I comandi che risolvono i nomi utente o elencano i membri del ruolo richiedono anche il permesso **Utente** in lettura.
+
+**Visualizza i ruoli:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <role_name>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Crea, aggiorna, elimina, abilita o disabilita un ruolo:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Restricted access"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "new note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+I nuovi ruoli creati da questo script non includono permessi di controllo. Configurarli nella console web prima di assegnare gli utenti. Questo script non gestisce né visualizza le definizioni dei permessi di controllo.
+
+**Gestisci i membri del ruolo:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+I ruoli e gli utenti di destinazione possono essere indicati anche tramite GUID. `remove-users` cancella il ruolo di controllo corrente di ogni utente, quindi non accetta `--name` o `--guid`. Per il ruolo riservato `Default`, `view-users` elenca solo le assegnazioni esplicite; anche gli utenti senza un ruolo di controllo assegnato ereditano `Default`. Il ruolo riservato `Not Logged` non può essere assegnato agli utenti e i ruoli riservati non possono essere rinominati, dotati di una nota o eliminati.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.ja.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.ja.md
@@ -117,7 +117,7 @@ Windowsクライアントの場合、カスタムサーバー設定を省略し�
 
 ## APIトークン
 
-まず、**設定 → トークン → 作成**に移動し、必要な権限（**デバイス、監査ログ、ユーザー、グループ、戦略、アドレス帳**）を持つトークンを作成する必要があります。
+まず、**設定 → トークン → 作成**に移動し、必要な権限（**デバイス、監査ログ、ユーザー、グループ、戦略、アドレス帳、管理者ロール、制御ロール**）を持つトークンを作成する必要があります。
 
 作成後、これらのトークンを**コマンドライン**または**Python CLI**を通じて使用し、対応する権限で操作を実行できます。
 
@@ -280,6 +280,107 @@ Windowsのコマンドラインはデフォルトでは出力を表示しませ�
 **権限要件:**
 - `view/add/update/delete/add-users` コマンドには **ユーザーグループ権限** が必要
 - `view-users` コマンドには **ユーザー権限** が必要
+
+---
+
+#### 管理者ロール管理 (`admin-roles.py`)
+
+トークンは完全な管理者に属し、**Admin Role** の読み取り権限または読み書き権限を持つ必要があります。ユーザー名の解決やロールメンバーの一覧表示には、**User** の読み取り権限も必要です。
+
+**ロールの表示：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <ロール名>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <ロールGUID>
+```
+
+**ロールの作成：**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "読み取り専用サポート"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+作成後にロールの種類を変更することはできません。`--permissions` には、カンマ区切りの権限名、10進数ID、または `0x` で始まるIDを指定でき、各形式を混在させることもできます。たとえば `users.view,513,0x0203` は `257,513,515` と同じです。選択したロールの種類で無効な権限はサーバーによって拒否されます。
+
+`view` コマンドは既知の権限IDを次の表の名前に戻します。スクリプトが認識しないIDは数値のまま保持されるため、新しいサーバーで追加された権限が隠れることはありません。
+
+| 領域 | 権限 | 有効なロールの種類 |
+| --- | --- | --- |
+| ユーザー | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| ユーザー | `users.change_group` (`268`) | `global` |
+| デバイス | `devices.view` (`513`) | `global`, `group` |
+| デバイス | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| デバイス | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| ユーザーグループ | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| デバイスグループ | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| 監査ログ | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| 戦略 | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| カスタムクライアント | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| 制御ロール | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**ロールの更新または削除：**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "新しいメモ"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+`--note`、`--permissions`、`--user-groups`、または `--device-groups` に空の値を渡すと、その項目をクリアできます（例：`--permissions ""`）。
+
+**ロールメンバーの管理：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+ロールとユーザーはGUIDでも指定できます。`--users` ではユーザー名とGUIDを混在させることができます。
+
+---
+
+#### 制御ロール管理 (`control-roles.py`)
+
+トークンには **Control Role** の読み取り権限または読み書き権限が必要です。ユーザー名の解決やロールメンバーの一覧表示には、**User** の読み取り権限も必要です。
+
+**ロールの表示：**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <ロール名>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <ロールGUID>
+```
+
+**ロールの作成、更新、削除、有効化、無効化：**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "制限付きアクセス"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "新しいメモ"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+このスクリプトで作成した新しいロールには制御権限が含まれません。ユーザーを割り当てる前に、Webコンソールで設定してください。このスクリプトは制御権限の定義を管理または表示しません。
+
+**ロールメンバーの管理：**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+ロールとユーザーはGUIDでも指定できます。`remove-users` は各ユーザーの現在の制御ロールを解除するため、`--name` または `--guid` は指定しません。予約済みの `Default` ロールでは、`view-users` は明示的な割り当てだけを表示します。制御ロールが割り当てられていないユーザーも `Default` を継承します。`Not Logged` ロールをユーザーに割り当てることはできず、予約済みロールの名前変更、メモ追加、削除もできません。
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.ko.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.ko.md
@@ -127,7 +127,7 @@ Windows 클라이언트의 경우 사용자 지정 서버 구성은 생략하고
 
 ## API 토큰
 
-먼저 **설정 → 토큰 → 생성**으로 이동해 필요한 권한을 가진 토큰을 생성해야 합니다: **장치, 감사 로그, 사용자, 그룹, 전략, 주소록**.  
+먼저 **설정 → 토큰 → 생성**으로 이동해 필요한 권한을 가진 토큰을 생성해야 합니다: **장치, 감사 로그, 사용자, 그룹, 전략, 주소록, 관리자 역할, 제어 역할**.
 
 토큰이 생성되면, 이를 **명령줄**이나 **파이썬 CLI**를 통해 해당 권한을 가진 작업을 수행하는 데 사용할 수 있습니다.
 
@@ -285,6 +285,107 @@ Windows의 명령줄은 기본적으로 출력이 없습니다. 출력을 얻으
 **권한 요구 사항:**
 - `view/add/update/delete/add-users` 명령은 **사용자 그룹 권한**이 필요합니다.
 - `view-users` 명령은 **사용자 권한**이 필요합니다.
+
+---
+
+#### 관리자 역할 관리 (`admin-roles.py`)
+
+토큰은 전체 관리자 계정에 속해야 하며 **Admin Role** 읽기 또는 읽기/쓰기 권한이 필요합니다. 사용자 이름을 확인하거나 역할 구성원을 나열하는 명령에는 **User** 읽기 권한도 필요합니다.
+
+**역할 보기:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <역할_이름>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <역할_GUID>
+```
+
+**역할 만들기:**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "읽기 전용 지원"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+역할 유형은 만든 후 변경할 수 없습니다. `--permissions`에는 쉼표로 구분한 권한 이름, 10진수 ID 또는 `0x`로 시작하는 ID를 지정할 수 있으며 형식을 혼합할 수도 있습니다. 예를 들어 `users.view,513,0x0203`은 `257,513,515`와 같습니다. 선택한 역할 유형에 유효하지 않은 권한은 서버에서 거부됩니다.
+
+`view` 명령은 알려진 권한 ID를 아래 표의 이름으로 변환합니다. 스크립트가 모르는 ID는 숫자로 유지되므로 최신 서버에서 추가된 권한이 숨겨지지 않습니다.
+
+| 영역 | 권한 | 유효한 역할 유형 |
+| --- | --- | --- |
+| 사용자 | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| 사용자 | `users.change_group` (`268`) | `global` |
+| 디바이스 | `devices.view` (`513`) | `global`, `group` |
+| 디바이스 | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| 디바이스 | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| 사용자 그룹 | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| 디바이스 그룹 | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| 감사 로그 | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| 전략 | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| 사용자 지정 클라이언트 | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| 제어 역할 | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**역할 업데이트 또는 삭제:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "새 메모"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+`--note`, `--permissions`, `--user-groups` 또는 `--device-groups`에 빈 값을 전달하면 해당 필드를 지울 수 있습니다. 예: `--permissions ""`.
+
+**역할 구성원 관리:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+역할과 사용자는 GUID로도 지정할 수 있습니다. `--users`에는 사용자 이름과 GUID를 함께 사용할 수 있습니다.
+
+---
+
+#### 제어 역할 관리 (`control-roles.py`)
+
+토큰에는 **Control Role** 읽기 또는 읽기/쓰기 권한이 필요합니다. 사용자 이름을 확인하거나 역할 구성원을 나열하는 명령에는 **User** 읽기 권한도 필요합니다.
+
+**역할 보기:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <역할_이름>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <역할_GUID>
+```
+
+**역할 만들기, 업데이트, 삭제, 활성화 또는 비활성화:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "제한된 액세스"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "새 메모"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+이 스크립트로 만든 새 역할에는 제어 권한이 포함되지 않습니다. 사용자를 할당하기 전에 웹 콘솔에서 설정하세요. 이 스크립트는 제어 권한 정의를 관리하거나 표시하지 않습니다.
+
+**역할 구성원 관리:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+역할과 사용자는 GUID로도 지정할 수 있습니다. `remove-users`는 각 사용자의 현재 제어 역할을 제거하므로 `--name`이나 `--guid`를 사용하지 않습니다. 예약된 `Default` 역할의 경우 `view-users`는 명시적 할당만 표시하며, 제어 역할이 할당되지 않은 사용자도 `Default`를 상속합니다. `Not Logged` 역할은 사용자에게 할당할 수 없으며 예약된 역할은 이름 변경, 메모 추가 또는 삭제할 수 없습니다.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.pl.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.pl.md
@@ -118,7 +118,7 @@ Aby przypisać strategię do urządzenia, najedź kursorem na prawą stronę lis
 
 ## Token API
 
-Najpierw przejdź do **Ustawienia → Tokeny → Utwórz** i utwórz token z wymaganymi uprawnieniami: **Urządzenie, Dziennik audytu, Użytkownik, Grupa, Strategia, Książka adresowa**.
+Najpierw przejdź do **Ustawienia → Tokeny → Utwórz** i utwórz token z wymaganymi uprawnieniami: **Urządzenie, Dziennik audytu, Użytkownik, Grupa, Strategia, Książka adresowa, Rola administratora, Rola sterowania**.
 
 Po utworzeniu tokeny te można używać przez **wiersz poleceń** lub **CLI w Pythonie**, aby wykonywać akcje z odpowiadającymi uprawnieniami.
 
@@ -281,6 +281,112 @@ zobacz [tutaj](https://github.com/rustdesk/rustdesk/discussions/6377#discussionc
 **Wymagania uprawnień:**
 - Polecenia `view/add/update/delete/add-users` wymagają **Uprawnienia Grupy Użytkowników**
 - Polecenie `view-users` wymaga **Uprawnienia Użytkownika**
+
+---
+
+#### Zarządzanie rolami administratora (`admin-roles.py`)
+
+Token musi należeć do pełnego administratora i mieć uprawnienie **Rola administratora** do odczytu lub odczytu/zapisu. Polecenia, które rozpoznają nazwy użytkowników lub wyświetlają członków roli, wymagają również uprawnienia **Użytkownik** do odczytu.
+
+**Wyświetlanie ról:**
+
+```bash
+# Wyświetla role, opcjonalnie filtrowane według dokładnej nazwy lub typu
+./admin-roles.py --url <url> --token <token> view [--name <role_name>] [--type global|individual|group]
+
+# Wyświetla jedną rolę według GUID
+./admin-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Tworzenie roli:**
+
+```bash
+# Rola globalna
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Read-only support"
+
+# Rola o zakresie grupowym
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+Typu roli nie można zmienić po jej utworzeniu. `--permissions` przyjmuje oddzielone przecinkami nazwy uprawnień, identyfikatory dziesiętne lub identyfikatory z prefiksem `0x`; formaty można łączyć. Na przykład `users.view,513,0x0203` jest równoważne `257,513,515`. Serwer odrzuca uprawnienia, które nie są prawidłowe dla wybranego typu roli.
+
+Polecenie `view` zamienia znane identyfikatory uprawnień z powrotem na poniższe nazwy. Identyfikator nieznany skryptowi pozostaje liczbą, dzięki czemu uprawnienia dodane przez nowszą wersję serwera nie są ukrywane.
+
+| Obszar | Uprawnienia | Prawidłowe typy ról |
+| --- | --- | --- |
+| Użytkownicy | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | global, group |
+| Użytkownicy | `users.change_group` (`268`) | global |
+| Urządzenia | `devices.view` (`513`) | global, group |
+| Urządzenia | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | global, individual, group |
+| Urządzenia | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | global |
+| Grupy użytkowników | `user_groups.view` (`769`); `user_groups.edit` (`770`) | global |
+| Grupy urządzeń | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | global |
+| Audyty | `audits.view` (`1281`); `audits.edit` (`1282`) | global, individual |
+| Strategie | `strategies.view` (`1537`); `strategies.edit` (`1538`) | global |
+| Klienci niestandardowi | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | global |
+| Role sterowania | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | global |
+
+**Aktualizowanie lub usuwanie roli:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "new note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Aby wyczyścić `--note`, `--permissions`, `--user-groups` lub `--device-groups`, przekaż pustą wartość, na przykład `--permissions ""`.
+
+**Zarządzanie członkami roli:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Role docelowe i użytkowników można również podawać za pomocą GUID. W `--users` można łączyć nazwy użytkowników i identyfikatory GUID.
+
+---
+
+#### Zarządzanie rolami sterowania (`control-roles.py`)
+
+Token wymaga uprawnienia **Rola sterowania** do odczytu lub odczytu/zapisu. Polecenia, które rozpoznają nazwy użytkowników lub wyświetlają członków roli, wymagają również uprawnienia **Użytkownik** do odczytu.
+
+**Wyświetlanie ról:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <role_name>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Tworzenie, aktualizowanie, usuwanie, włączanie lub wyłączanie roli:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Restricted access"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "new note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+Nowe role utworzone przez ten skrypt nie zawierają uprawnień sterowania. Skonfiguruj je w konsoli internetowej przed przypisaniem użytkowników. Ten skrypt nie zarządza definicjami uprawnień sterowania ani ich nie wyświetla.
+
+**Zarządzanie członkami roli:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Role docelowe i użytkowników można również podawać za pomocą GUID. `remove-users` usuwa bieżącą rolę sterowania każdego użytkownika, dlatego nie przyjmuje `--name` ani `--guid`. W przypadku zastrzeżonej roli `Default` polecenie `view-users` wyświetla tylko jawne przypisania; użytkownicy bez przypisanej roli sterowania również dziedziczą rolę `Default`. Zastrzeżonej roli `Not Logged` nie można przypisywać użytkownikom, a nazw zastrzeżonych ról nie można zmieniać, dodawać do nich notatek ani ich usuwać.
 
 ---
 
@@ -559,7 +665,7 @@ Aby przypisać strategię do urządzenia, najedź kursorem na prawą stronę lis
 
 ## Token API
 
-Najpierw przejdź do **Ustawienia → Tokeny → Utwórz** i utwórz token z wymaganymi uprawnieniami: **Urządzenie, Dziennik audytu, Użytkownik, Grupa, Strategia, Książka adresowa**.
+Najpierw przejdź do **Ustawienia → Tokeny → Utwórz** i utwórz token z wymaganymi uprawnieniami: **Urządzenie, Dziennik audytu, Użytkownik, Grupa, Strategia, Książka adresowa, Rola administratora, Rola sterowania**.
 
 Po utworzeniu tokeny te można używać przez **wiersz poleceń** lub **CLI w Pythonie**, aby wykonywać akcje z odpowiadającymi uprawnieniami.
 

--- a/content/self-host/rustdesk-server-pro/console/_index.pt.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.pt.md
@@ -117,7 +117,7 @@ Para atribuir uma estratégia a um dispositivo, passe o mouse sobre o lado direi
 
 ## Token de API
 
-Primeiro, você deve ir em **Configurações → Tokens → Criar** e criar um token com as permissões necessárias: **Dispositivo, Registro de Auditoria, Usuário, Grupo, Estratégia, Livro de Endereços**.
+Primeiro, você deve ir em **Configurações → Tokens → Criar** e criar um token com as permissões necessárias: **Dispositivo, Registro de Auditoria, Usuário, Grupo, Estratégia, Livro de Endereços, Função de Administrador, Função de Controle**.
 
 Depois de criado, você pode usar esses tokens via **linha de comando** ou **CLI Python** para executar ações com as permissões correspondentes.
 
@@ -280,6 +280,112 @@ veja [aqui](https://github.com/rustdesk/rustdesk/discussions/6377#discussioncomm
 **Requisitos de permissões:**
 - Os comandos `view/add/update/delete/add-users` requerem **Permissão de Grupo de Usuários**
 - O comando `view-users` requer **Permissão de Usuário**
+
+---
+
+#### Gerenciamento de funções de administrador (`admin-roles.py`)
+
+O token deve pertencer a um administrador completo e ter a permissão **Função de Administrador** de leitura ou leitura/gravação. Os comandos que resolvem nomes de usuários ou listam membros da função também exigem a permissão **Usuário** de leitura.
+
+**Visualizar funções:**
+
+```bash
+# Lista funções, opcionalmente filtradas pelo nome exato ou tipo
+./admin-roles.py --url <url> --token <token> view [--name <role_name>] [--type global|individual|group]
+
+# Visualiza uma função pelo GUID
+./admin-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Criar uma função:**
+
+```bash
+# Função global
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Read-only support"
+
+# Função com escopo de grupo
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+O tipo da função não pode ser alterado após a criação. `--permissions` aceita nomes de permissões, IDs decimais ou IDs com o prefixo `0x`, separados por vírgulas; os formatos podem ser combinados. Por exemplo, `users.view,513,0x0203` equivale a `257,513,515`. O servidor rejeita permissões que não são válidas para o tipo de função selecionado.
+
+O comando `view` converte os IDs de permissões conhecidos de volta para os nomes abaixo. Um ID desconhecido pelo script é mantido como número, para que permissões adicionadas por uma versão mais recente do servidor não fiquem ocultas.
+
+| Área | Permissões | Tipos de função válidos |
+| --- | --- | --- |
+| Usuários | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | global, group |
+| Usuários | `users.change_group` (`268`) | global |
+| Dispositivos | `devices.view` (`513`) | global, group |
+| Dispositivos | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | global, individual, group |
+| Dispositivos | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | global |
+| Grupos de usuários | `user_groups.view` (`769`); `user_groups.edit` (`770`) | global |
+| Grupos de dispositivos | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | global |
+| Auditorias | `audits.view` (`1281`); `audits.edit` (`1282`) | global, individual |
+| Estratégias | `strategies.view` (`1537`); `strategies.edit` (`1538`) | global |
+| Clientes personalizados | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | global |
+| Funções de controle | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | global |
+
+**Atualizar ou excluir uma função:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "new note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Passe um valor vazio para limpar `--note`, `--permissions`, `--user-groups` ou `--device-groups`, por exemplo, `--permissions ""`.
+
+**Gerenciar membros da função:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+As funções e os usuários de destino também podem ser informados por GUID. Nomes de usuários e GUIDs podem ser combinados em `--users`.
+
+---
+
+#### Gerenciamento de funções de controle (`control-roles.py`)
+
+O token precisa da permissão **Função de Controle** de leitura ou leitura/gravação. Os comandos que resolvem nomes de usuários ou listam membros da função também exigem a permissão **Usuário** de leitura.
+
+**Visualizar funções:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <role_name>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Criar, atualizar, excluir, habilitar ou desabilitar uma função:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Restricted access"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "new note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+As novas funções criadas por este script não incluem permissões de controle. Configure-as no console web antes de atribuir usuários. Este script não gerencia nem exibe as definições de permissões de controle.
+
+**Gerenciar membros da função:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+As funções e os usuários de destino também podem ser informados por GUID. `remove-users` limpa a função de controle atual de cada usuário, portanto não aceita `--name` nem `--guid`. Para a função reservada `Default`, `view-users` lista somente as atribuições explícitas; os usuários sem uma função de controle atribuída também herdam `Default`. A função reservada `Not Logged` não pode ser atribuída a usuários, e as funções reservadas não podem ser renomeadas, receber uma nota ou ser excluídas.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.ro.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.ro.md
@@ -116,7 +116,7 @@ Pentru a atribui o strategie unui dispozitiv, plasează cursorul în partea drea
 
 ## Token API
 
-Mai întâi trebuie să mergi la **Settings → Tokens → Create** și să creezi un token cu permisiunile necesare: **Device, Audit Log, User, Group, Strategy, Address Book**.
+Mai întâi trebuie să mergi la **Settings → Tokens → Create** și să creezi un token cu permisiunile necesare: **Device, Audit Log, User, Group, Strategy, Address Book, Admin Role, Control Role**.
 
 Odată creat, poți folosi aceste token-uri din linia de comandă sau din CLI Python pentru a efectua acțiuni cu permisiunile respective.
 
@@ -275,6 +275,112 @@ Linia de comandă pe Windows nu afișează output implicit. Pentru a obține out
 **Cerințe de permisiuni:**
 - Comenzile `view/add/update/delete/add-users` necesită **Permisiune Grup Utilizatori**
 - Comanda `view-users` necesită **Permisiune Utilizator**
+
+---
+
+#### Gestionarea rolurilor de administrator (`admin-roles.py`)
+
+Tokenul trebuie să aparțină unui administrator complet și să aibă permisiunea **Rol de administrator** de citire sau citire/scriere. Comenzile care identifică numele utilizatorilor sau listează membrii rolului necesită și permisiunea **Utilizator** de citire.
+
+**Vizualizarea rolurilor:**
+
+```bash
+# Listează rolurile, filtrate opțional după numele exact sau tip
+./admin-roles.py --url <url> --token <token> view [--name <role_name>] [--type global|individual|group]
+
+# Vizualizează un rol după GUID
+./admin-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Crearea unui rol:**
+
+```bash
+# Rol global
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "Read-only support"
+
+# Rol cu domeniu de aplicare la nivel de grup
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+Tipul rolului nu poate fi schimbat după creare. `--permissions` acceptă nume de permisiuni, ID-uri zecimale sau ID-uri cu prefixul `0x`, separate prin virgulă; formatele pot fi combinate. De exemplu, `users.view,513,0x0203` este echivalent cu `257,513,515`. Serverul respinge permisiunile care nu sunt valide pentru tipul de rol selectat.
+
+Comanda `view` convertește ID-urile de permisiuni cunoscute înapoi la numele de mai jos. Un ID necunoscut scriptului este păstrat ca număr, astfel încât permisiunile adăugate de o versiune mai nouă a serverului să nu fie ascunse.
+
+| Zonă | Permisiuni | Tipuri de rol valide |
+| --- | --- | --- |
+| Utilizatori | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | global, group |
+| Utilizatori | `users.change_group` (`268`) | global |
+| Dispozitive | `devices.view` (`513`) | global, group |
+| Dispozitive | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | global, individual, group |
+| Dispozitive | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | global |
+| Grupuri de utilizatori | `user_groups.view` (`769`); `user_groups.edit` (`770`) | global |
+| Grupuri de dispozitive | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | global |
+| Audituri | `audits.view` (`1281`); `audits.edit` (`1282`) | global, individual |
+| Strategii | `strategies.view` (`1537`); `strategies.edit` (`1538`) | global |
+| Clienți personalizați | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | global |
+| Roluri de control | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | global |
+
+**Actualizarea sau ștergerea unui rol:**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "new note"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+Transmiteți o valoare goală pentru a șterge `--note`, `--permissions`, `--user-groups` sau `--device-groups`, de exemplu `--permissions ""`.
+
+**Gestionarea membrilor rolului:**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+Rolurile țintă și utilizatorii pot fi specificați și prin GUID. Numele utilizatorilor și GUID-urile pot fi combinate în `--users`.
+
+---
+
+#### Gestionarea rolurilor de control (`control-roles.py`)
+
+Tokenul necesită permisiunea **Rol de control** de citire sau citire/scriere. Comenzile care identifică numele utilizatorilor sau listează membrii rolului necesită și permisiunea **Utilizator** de citire.
+
+**Vizualizarea rolurilor:**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <role_name>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <role_guid>
+```
+
+**Crearea, actualizarea, ștergerea, activarea sau dezactivarea unui rol:**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "Restricted access"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "new note"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+Rolurile noi create de acest script nu includ permisiuni de control. Configurați-le în consola web înainte de a atribui utilizatori. Acest script nu gestionează și nu afișează definițiile permisiunilor de control.
+
+**Gestionarea membrilor rolului:**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+Rolurile țintă și utilizatorii pot fi specificați și prin GUID. `remove-users` elimină rolul de control curent al fiecărui utilizator, deci nu acceptă `--name` sau `--guid`. Pentru rolul rezervat `Default`, `view-users` listează numai atribuirile explicite; utilizatorii fără un rol de control atribuit moștenesc, de asemenea, rolul `Default`. Rolul rezervat `Not Logged` nu poate fi atribuit utilizatorilor, iar rolurile rezervate nu pot fi redenumite, nu pot primi o notă și nu pot fi șterse.
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.zh-cn.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.zh-cn.md
@@ -120,7 +120,7 @@ RustDesk Server Pro Web 控制台是管理用户、设备、分组、授权、�
 ## API 令牌（Token）
 
 首先，请前往 **Settings → Tokens → Create** 创建一个具有所需权限的令牌，所需权限包括：  
-**Device, Audit Log, User, Group, Strategy, Address Book**。
+**Device, Audit Log, User, Group, Strategy, Address Book, Admin Role, Control Role**。
 
 创建完成后，可以通过 **命令行 (Command Line)** 或 **Python CLI** 使用这些令牌执行相应权限的操作。
 
@@ -288,6 +288,107 @@ Windows 命令行默认无输出，如需查看输出，可使用如下方式运
 **权限要求：**
 - `view/add/update/delete/add-users` 命令需要 **用户组权限**
 - `view-users` 命令需要 **用户权限**
+
+---
+
+#### 管理员角色管理 (`admin-roles.py`)
+
+令牌必须属于完整管理员，并具有 **Admin Role** 读取或读写权限。解析用户名或列出角色成员的命令还需要 **User** 读取权限。
+
+**查看角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <角色名称>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <角色GUID>
+```
+
+**创建角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "只读支持"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+角色创建后不能更改类型。`--permissions` 接受逗号分隔的权限名称、十进制 ID 或以 `0x` 开头的 ID，也可以混用。例如，`users.view,513,0x0203` 等同于 `257,513,515`。服务器会拒绝不适用于所选角色类型的权限。
+
+`view` 会把已知权限 ID 转换回下表中的名称。脚本不认识的 ID 会保留为数字，以免隐藏较新服务器增加的权限。
+
+| 区域 | 权限 | 有效角色类型 |
+| --- | --- | --- |
+| 用户 | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| 用户 | `users.change_group` (`268`) | `global` |
+| 设备 | `devices.view` (`513`) | `global`, `group` |
+| 设备 | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| 设备 | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| 用户组 | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| 设备组 | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| 审计日志 | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| 策略 | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| 自定义客户端 | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| 控制角色 | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**更新或删除角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "新备注"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+为 `--note`、`--permissions`、`--user-groups` 或 `--device-groups` 传入空值可清除该字段，例如 `--permissions ""`。
+
+**管理角色成员：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+角色目标和用户也可以使用 GUID。`--users` 中可以混用用户名和 GUID。
+
+---
+
+#### 控制角色管理 (`control-roles.py`)
+
+令牌需要 **Control Role** 读取或读写权限。解析用户名或列出角色成员的命令还需要 **User** 读取权限。
+
+**查看角色：**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <角色名称>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <角色GUID>
+```
+
+**创建、更新、删除、启用或禁用角色：**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "受限访问"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "新备注"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+此脚本创建的新角色不包含控制权限。请先在 Web 控制台中配置，再分配用户。此脚本不管理或显示控制权限定义。
+
+**管理角色成员：**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+角色目标和用户也可以使用 GUID。`remove-users` 会清除每个用户当前的控制角色，因此不接受 `--name` 或 `--guid`。对于保留的 `Default` 角色，`view-users` 只列出显式分配；未分配控制角色的用户也会继承 `Default`。`Not Logged` 角色不能分配给用户，保留角色不能重命名、添加备注或删除。
 
 ---
 

--- a/content/self-host/rustdesk-server-pro/console/_index.zh-tw.md
+++ b/content/self-host/rustdesk-server-pro/console/_index.zh-tw.md
@@ -117,7 +117,7 @@ RustDesk Server Pro Web 主控台是管理使用者、裝置、群組、授權�
 
 ## API Token
 
-首先，需前往 **設定 → Token → 建立**，並建立擁有所需權限的權杖：**設備、審計日誌、使用者、群組、策略、通訊錄**。
+首先，需前往 **設定 → Token → 建立**，並建立擁有所需權限的權杖：**設備、審計日誌、使用者、群組、策略、通訊錄、管理員角色、控制角色**。
 
 建立後，可透過 **命令列** 或 **Python CLI** 使用這些權杖，執行擁有相應權限的操作。
 
@@ -280,6 +280,107 @@ Windows 命令列預設不會輸出結果。若要查看輸出，可使用：
 **權限要求：**
 - `view/add/update/delete/add-users` 命令需要 **使用者群組權限**
 - `view-users` 命令需要 **使用者權限**
+
+---
+
+#### 管理員角色管理 (`admin-roles.py`)
+
+權杖必須屬於完整管理員，並具有 **Admin Role** 讀取或讀寫權限。解析使用者名稱或列出角色成員的命令還需要 **User** 讀取權限。
+
+**查看角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view [--name <角色名稱>] [--type global|individual|group]
+./admin-roles.py --url <url> --token <token> view --guid <角色GUID>
+```
+
+**建立角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Admin" --type global \
+  --permissions "users.view,devices.view,audits.view" --note "唯讀支援"
+
+./admin-roles.py --url <url> --token <token> add \
+  --name "Support Scope" --type group \
+  --permissions "users.view,devices.view,devices.enable_disable" \
+  --user-groups "Support" --device-groups "Servers" --unassigned
+```
+
+角色建立後不能變更類型。`--permissions` 接受逗號分隔的權限名稱、十進位 ID 或以 `0x` 開頭的 ID，也可以混用。例如，`users.view,513,0x0203` 等同於 `257,513,515`。伺服器會拒絕不適用於所選角色類型的權限。
+
+`view` 會把已知權限 ID 轉換回下表中的名稱。腳本不認識的 ID 會保留為數字，以免隱藏較新伺服器增加的權限。
+
+| 區域 | 權限 | 有效角色類型 |
+| --- | --- | --- |
+| 使用者 | `users.view` (`257`); `users.create` (`259`); `users.invite` (`260`); `users.delete` (`261`); `users.enable_disable` (`262`); `users.edit_email` (`263`); `users.edit_password` (`264`); `users.edit_note` (`265`); `users.manage_2fa` (`266`); `users.force_logout` (`267`); `users.change_strategy` (`269`); `users.change_control_role` (`270`); `users.edit_display_name` (`271`) | `global`, `group` |
+| 使用者 | `users.change_group` (`268`) | `global` |
+| 設備 | `devices.view` (`513`) | `global`, `group` |
+| 設備 | `devices.enable_disable` (`515`); `devices.delete` (`516`); `devices.edit_info` (`517`); `devices.change_strategy` (`520`) | `global`, `individual`, `group` |
+| 設備 | `devices.assign_to_user` (`518`); `devices.change_group` (`519`) | `global` |
+| 使用者群組 | `user_groups.view` (`769`); `user_groups.edit` (`770`) | `global` |
+| 設備群組 | `device_groups.view` (`1025`); `device_groups.edit` (`1026`); `device_groups.change_strategy` (`1027`) | `global` |
+| 稽核日誌 | `audits.view` (`1281`); `audits.edit` (`1282`) | `global`, `individual` |
+| 策略 | `strategies.view` (`1537`); `strategies.edit` (`1538`) | `global` |
+| 自訂客戶端 | `custom_clients.view` (`1793`); `custom_clients.edit` (`1794`) | `global` |
+| 控制角色 | `control_roles.view` (`2049`); `control_roles.edit` (`2050`) | `global` |
+
+**更新或刪除角色：**
+
+```bash
+./admin-roles.py --url <url> --token <token> update --name "Support Admin" \
+  [--new-name "Helpdesk Admin"] [--note "新備註"] [--permissions "users.view,devices.view"] \
+  [--user-groups "Support"] [--device-groups "Servers"] [--unassigned|--no-unassigned]
+
+./admin-roles.py --url <url> --token <token> delete --name "Support Admin"
+```
+
+為 `--note`、`--permissions`、`--user-groups` 或 `--device-groups` 傳入空值可清除該欄位，例如 `--permissions ""`。
+
+**管理角色成員：**
+
+```bash
+./admin-roles.py --url <url> --token <token> view-users --name "Support Admin"
+./admin-roles.py --url <url> --token <token> add-users --name "Support Admin" --users "user1,user2"
+./admin-roles.py --url <url> --token <token> remove-users --name "Support Admin" --users "user1,user2"
+```
+
+角色目標和使用者也可以使用 GUID。`--users` 中可以混用使用者名稱和 GUID。
+
+---
+
+#### 控制角色管理 (`control-roles.py`)
+
+權杖需要 **Control Role** 讀取或讀寫權限。解析使用者名稱或列出角色成員的命令還需要 **User** 讀取權限。
+
+**查看角色：**
+
+```bash
+./control-roles.py --url <url> --token <token> view [--name <角色名稱>] [--status enabled|disabled]
+./control-roles.py --url <url> --token <token> view --guid <角色GUID>
+```
+
+**建立、更新、刪除、啟用或停用角色：**
+
+```bash
+./control-roles.py --url <url> --token <token> add --name "Contractors" [--note "受限存取"]
+./control-roles.py --url <url> --token <token> update --name "Contractors" [--new-name "Vendors"] [--note "新備註"]
+./control-roles.py --url <url> --token <token> delete --name "Contractors"
+./control-roles.py --url <url> --token <token> enable --name "Contractors"
+./control-roles.py --url <url> --token <token> disable --name "Contractors"
+```
+
+此腳本建立的新角色不包含控制權限。請先在 Web 主控台中設定，再分配使用者。此腳本不管理或顯示控制權限定義。
+
+**管理角色成員：**
+
+```bash
+./control-roles.py --url <url> --token <token> view-users --name "Contractors"
+./control-roles.py --url <url> --token <token> assign-users --name "Contractors" --users "user1,user2"
+./control-roles.py --url <url> --token <token> remove-users --users "user1,user2"
+```
+
+角色目標和使用者也可以使用 GUID。`remove-users` 會清除每位使用者目前的控制角色，因此不接受 `--name` 或 `--guid`。對於保留的 `Default` 角色，`view-users` 只列出明確分配；未分配控制角色的使用者也會繼承 `Default`。`Not Logged` 角色不能分配給使用者，保留角色不能重新命名、新增備註或刪除。
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added multilingual documentation for managing administrator and control roles with the `admin-roles.py` and `control-roles.py` CLI tools.
  - Documented role creation, updates, deletion, enablement, permissions, and member management.
  - Expanded API token guidance to include Admin Role and Control Role permissions.
  - Added permission ID tables, role-type guidance, and reserved-role behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->